### PR TITLE
Postgres extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ is described in a block passed to `#table`.
 
 ``` ruby
 DbSchema.describe do |db|
+  db.extension :hstore
+
   db.table :users do |t|
     t.primary_key :id
     t.varchar     :email,    null: false
@@ -149,6 +151,7 @@ DbSchema.describe do |db|
     t.varchar     :name,     null: false
     t.integer     :age
     t.user_status :status,   null: false, default: 'registered'
+    t.hstore      :tracking, null: false, default: ''
 
     t.index :email, unique: true
   end
@@ -252,6 +255,20 @@ Other attributes are type specific, like `:length` for varchars; the following t
 | `tsrange`     |                  |
 | `tstzrange`   |                  |
 | `daterange`   |                  |
+| `chkpass`     |                  |
+| `citext`      |                  |
+| `cube`        |                  |
+| `hstore`      |                  |
+| `ean13`       |                  |
+| `isbn13`      |                  |
+| `ismn13`      |                  |
+| `issn13`      |                  |
+| `isbn`        |                  |
+| `ismn`        |                  |
+| `issn`        |                  |
+| `upc`         |                  |
+| `ltree`       |                  |
+| `seg`         |                  |
 
 The `of` attribute of the array type is the only required attribute (you need to specify the array element type here); other attributes either have default values or can be omitted at all.
 
@@ -436,6 +453,16 @@ db.enum :user_status, [:guest, :registered, :sent_confirmation_email, :confirmed
 ```
 
 Reordering and deleting values from enum types is not supported.
+
+### Extensions
+
+PostgreSQL has a [wide variety](https://www.postgresql.org/docs/9.5/static/contrib.html) of extensions providing additional data types, functions and operators. You can use DbSchema to add and remove extensions in your database:
+
+``` ruby
+db.extension :hstore
+```
+
+*Note that adding and removing extensions in Postgres requires superuser privileges.*
 
 ## Configuration
 

--- a/lib/db_schema/awesome_print.rb
+++ b/lib/db_schema/awesome_print.rb
@@ -70,6 +70,9 @@ if defined?(AwesomePrint)
           :dbschema_column_operation
         when ::DbSchema::Changes::AddValueToEnum
           :dbschema_add_value_to_enum
+        when ::DbSchema::Changes::CreateExtension,
+             ::DbSchema::Changes::DropExtension
+          :dbschema_column_operation
         else
           cast_without_dbschema(object, type)
         end

--- a/lib/db_schema/awesome_print.rb
+++ b/lib/db_schema/awesome_print.rb
@@ -29,6 +29,8 @@ if defined?(AwesomePrint)
           :dbschema_foreign_key
         when ::DbSchema::Definitions::Enum
           :dbschema_enum
+        when ::DbSchema::Definitions::Extension
+          :dbschema_column_operation
         when ::DbSchema::Changes::CreateTable
           :dbschema_create_table
         when ::DbSchema::Changes::DropTable

--- a/lib/db_schema/definitions.rb
+++ b/lib/db_schema/definitions.rb
@@ -116,6 +116,15 @@ module DbSchema
         @values = values
       end
     end
+
+    class Extension
+      include Dry::Equalizer(:name)
+      attr_reader :name
+
+      def initialize(name)
+        @name = name
+      end
+    end
   end
 end
 

--- a/lib/db_schema/definitions/field.rb
+++ b/lib/db_schema/definitions/field.rb
@@ -3,7 +3,11 @@ module DbSchema
     module Field
       class << self
         def build(name, type, **options)
-          type_class_for(type).new(name, **options)
+          if registry.key?(type)
+            type_class_for(type).new(name, **options)
+          else
+            Custom.new(name, type_name: type, **options)
+          end
         end
 
         def type_class_for(type)
@@ -35,4 +39,7 @@ require_relative 'field/uuid'
 require_relative 'field/json'
 require_relative 'field/array'
 require_relative 'field/range'
+
+require_relative 'field/extensions/ltree'
+
 require_relative 'field/custom'

--- a/lib/db_schema/definitions/field.rb
+++ b/lib/db_schema/definitions/field.rb
@@ -40,6 +40,9 @@ require_relative 'field/json'
 require_relative 'field/array'
 require_relative 'field/range'
 
+require_relative 'field/extensions/chkpass'
+require_relative 'field/extensions/citext'
+require_relative 'field/extensions/cube'
 require_relative 'field/extensions/hstore'
 require_relative 'field/extensions/ltree'
 

--- a/lib/db_schema/definitions/field.rb
+++ b/lib/db_schema/definitions/field.rb
@@ -40,6 +40,7 @@ require_relative 'field/json'
 require_relative 'field/array'
 require_relative 'field/range'
 
+require_relative 'field/extensions/hstore'
 require_relative 'field/extensions/ltree'
 
 require_relative 'field/custom'

--- a/lib/db_schema/definitions/field.rb
+++ b/lib/db_schema/definitions/field.rb
@@ -44,6 +44,8 @@ require_relative 'field/extensions/chkpass'
 require_relative 'field/extensions/citext'
 require_relative 'field/extensions/cube'
 require_relative 'field/extensions/hstore'
+require_relative 'field/extensions/isn'
 require_relative 'field/extensions/ltree'
+require_relative 'field/extensions/seg'
 
 require_relative 'field/custom'

--- a/lib/db_schema/definitions/field/extensions/chkpass.rb
+++ b/lib/db_schema/definitions/field/extensions/chkpass.rb
@@ -1,0 +1,9 @@
+module DbSchema
+  module Definitions
+    module Field
+      class Chkpass < Base
+        register :chkpass
+      end
+    end
+  end
+end

--- a/lib/db_schema/definitions/field/extensions/citext.rb
+++ b/lib/db_schema/definitions/field/extensions/citext.rb
@@ -1,0 +1,9 @@
+module DbSchema
+  module Definitions
+    module Field
+      class Citext < Base
+        register :citext
+      end
+    end
+  end
+end

--- a/lib/db_schema/definitions/field/extensions/cube.rb
+++ b/lib/db_schema/definitions/field/extensions/cube.rb
@@ -1,0 +1,9 @@
+module DbSchema
+  module Definitions
+    module Field
+      class Cube < Base
+        register :cube
+      end
+    end
+  end
+end

--- a/lib/db_schema/definitions/field/extensions/hstore.rb
+++ b/lib/db_schema/definitions/field/extensions/hstore.rb
@@ -1,0 +1,9 @@
+module DbSchema
+  module Definitions
+    module Field
+      class Hstore < Base
+        register :hstore
+      end
+    end
+  end
+end

--- a/lib/db_schema/definitions/field/extensions/isn.rb
+++ b/lib/db_schema/definitions/field/extensions/isn.rb
@@ -1,0 +1,37 @@
+module DbSchema
+  module Definitions
+    module Field
+      class EAN13 < Base
+        register :ean13
+      end
+
+      class ISBN13 < Base
+        register :isbn13
+      end
+
+      class ISMN13 < Base
+        register :ismn13
+      end
+
+      class ISSN13 < Base
+        register :issn13
+      end
+
+      class ISBN < Base
+        register :isbn
+      end
+
+      class ISMN < Base
+        register :ismn
+      end
+
+      class ISSN < Base
+        register :issn
+      end
+
+      class UPC < Base
+        register :upc
+      end
+    end
+  end
+end

--- a/lib/db_schema/definitions/field/extensions/ltree.rb
+++ b/lib/db_schema/definitions/field/extensions/ltree.rb
@@ -1,0 +1,9 @@
+module DbSchema
+  module Definitions
+    module Field
+      class Ltree < Base
+        register :ltree
+      end
+    end
+  end
+end

--- a/lib/db_schema/definitions/field/extensions/seg.rb
+++ b/lib/db_schema/definitions/field/extensions/seg.rb
@@ -1,0 +1,9 @@
+module DbSchema
+  module Definitions
+    module Field
+      class Seg < Base
+        register :seg
+      end
+    end
+  end
+end

--- a/lib/db_schema/dsl.rb
+++ b/lib/db_schema/dsl.rb
@@ -29,6 +29,10 @@ module DbSchema
       @schema << Definitions::Enum.new(name.to_sym, values.map(&:to_sym))
     end
 
+    def extension(name)
+      @schema << Definitions::Extension.new(name.to_sym)
+    end
+
     class TableYielder
       attr_reader :table_name
 

--- a/lib/db_schema/reader.rb
+++ b/lib/db_schema/reader.rb
@@ -174,6 +174,9 @@ SELECT extname
       private
         def build_field(data, primary_key: false)
           type = data[:type].to_sym.downcase
+          if type == :'user-defined'
+            type = data[:custom_type_name].to_sym
+          end
 
           nullable = (data[:null] != 'NO')
 
@@ -222,24 +225,14 @@ SELECT extname
             {}
           end
 
-          if data[:type] == 'USER-DEFINED'
-            Definitions::Field::Custom.new(
-              data[:name].to_sym,
-              type_name:   data[:custom_type_name].to_sym,
-              primary_key: primary_key,
-              null:        nullable,
-              default:     default
-            )
-          else
-            Definitions::Field.build(
-              data[:name].to_sym,
-              type,
-              primary_key: primary_key,
-              null:        nullable,
-              default:     default,
-              **options
-            )
-          end
+          Definitions::Field.build(
+            data[:name].to_sym,
+            type,
+            primary_key: primary_key,
+            null:        nullable,
+            default:     default,
+            **options
+          )
         end
 
         def build_foreign_key(data)

--- a/lib/db_schema/runner.rb
+++ b/lib/db_schema/runner.rb
@@ -194,11 +194,11 @@ module DbSchema
       end
 
       def create_extension(change)
-        DbSchema.connection.run("CREATE EXTENSION #{change.name}")
+        DbSchema.connection.run(%Q(CREATE EXTENSION "#{change.name}"))
       end
 
       def drop_extension(change)
-        DbSchema.connection.run("DROP EXTENSION #{change.name}")
+        DbSchema.connection.run(%Q(DROP EXTENSION "#{change.name}"))
       end
 
       def map_options(type, options)

--- a/lib/db_schema/runner.rb
+++ b/lib/db_schema/runner.rb
@@ -24,6 +24,10 @@ module DbSchema
             self.class.create_enum(change)
           when Changes::DropEnum
             self.class.drop_enum(change)
+          when Changes::CreateExtension
+            self.class.create_extension(change)
+          when Changes::DropExtension
+            self.class.drop_extension(change)
           end
         end
       end
@@ -39,6 +43,7 @@ module DbSchema
       Utils.sort_by_class(
         changes,
         [
+          Changes::CreateExtension,
           Changes::AddValueToEnum,
           Changes::DropForeignKey,
           Changes::CreateEnum,
@@ -46,7 +51,8 @@ module DbSchema
           Changes::AlterTable,
           Changes::DropTable,
           Changes::DropEnum,
-          Changes::CreateForeignKey
+          Changes::CreateForeignKey,
+          Changes::DropExtension
         ]
       )
     end
@@ -185,6 +191,14 @@ module DbSchema
         else
           DbSchema.connection.add_enum_value(change.enum_name, change.new_value, before: change.before)
         end
+      end
+
+      def create_extension(change)
+        DbSchema.connection.run("CREATE EXTENSION #{change.name}")
+      end
+
+      def drop_extension(change)
+        DbSchema.connection.run("DROP EXTENSION #{change.name}")
       end
 
       def map_options(type, options)

--- a/spec/db_schema/changes_spec.rb
+++ b/spec/db_schema/changes_spec.rb
@@ -457,5 +457,31 @@ RSpec.describe DbSchema::Changes do
         end
       end
     end
+
+    context 'with extensions added and removed' do
+      let(:desired_schema) do
+        [
+          DbSchema::Definitions::Extension.new(:ltree)
+        ]
+      end
+
+      let(:actual_schema) do
+        [
+          DbSchema::Definitions::Extension.new(:hstore)
+        ]
+      end
+
+      it 'returns changes between schemas' do
+        changes = DbSchema::Changes.between(desired_schema, actual_schema)
+
+        expect(changes.count).to eq(2)
+        expect(changes).to include(
+          DbSchema::Changes::CreateExtension.new(:ltree)
+        )
+        expect(changes).to include(
+          DbSchema::Changes::DropExtension.new(:hstore)
+        )
+      end
+    end
   end
 end

--- a/spec/db_schema/dsl_spec.rb
+++ b/spec/db_schema/dsl_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe DbSchema::DSL do
       -> (db) do
         db.enum :user_status, %i(user moderator admin)
 
+        db.extension :hstore
+
         db.table :users do |t|
           t.primary_key :id
           t.varchar     :name, null: false
@@ -45,8 +47,13 @@ RSpec.describe DbSchema::DSL do
 
     subject { DbSchema::DSL.new(schema_block) }
 
-    it 'returns an array of Definitions::Table instances' do
-      user_status, users, happiness, posts = subject.schema
+    it 'returns a schema definition' do
+      user_status, hstore, users, happiness, posts = subject.schema
+
+      expect(user_status.name).to eq(:user_status)
+      expect(user_status.values).to eq(%i(user moderator admin))
+
+      expect(hstore).to eq(DbSchema::Definitions::Extension.new(:hstore))
 
       expect(users.name).to eq(:users)
       expect(users.fields.count).to eq(8)

--- a/spec/db_schema/reader_spec.rb
+++ b/spec/db_schema/reader_spec.rb
@@ -8,9 +8,11 @@ RSpec.describe DbSchema::Reader do
       end
     end
 
-    context 'on a database with tables' do
+    context 'on a non-empty database' do
       before(:each) do
         DbSchema.connection.create_enum :rainbow, %w(red orange yellow green blue purple)
+
+        DbSchema.connection.run('CREATE EXTENSION hstore')
 
         DbSchema.connection.create_table :users do
           column :id, :serial, primary_key: true
@@ -58,10 +60,12 @@ RSpec.describe DbSchema::Reader do
       end
 
       it 'returns the database schema' do
-        rainbow, users, posts = subject.read_schema
+        rainbow, hstore, users, posts = subject.read_schema
 
         expect(rainbow.name).to eq(:rainbow)
         expect(rainbow.values).to eq(%i(red orange yellow green blue purple))
+
+        expect(hstore.name).to eq(:hstore)
 
         expect(users.name).to eq(:users)
         expect(posts.name).to eq(:posts)
@@ -197,6 +201,7 @@ RSpec.describe DbSchema::Reader do
         DbSchema.connection.drop_table(:posts)
         DbSchema.connection.drop_table(:users)
         DbSchema.connection.drop_enum(:rainbow)
+        DbSchema.connection.run('DROP EXTENSION hstore')
       end
     end
   end

--- a/spec/db_schema/runner_spec.rb
+++ b/spec/db_schema/runner_spec.rb
@@ -766,6 +766,7 @@ RSpec.describe DbSchema::Runner do
       let(:changes) do
         [
           DbSchema::Changes::CreateExtension.new(:ltree),
+          DbSchema::Changes::CreateExtension.new(:'uuid-ossp'),
           DbSchema::Changes::DropExtension.new(:hstore)
         ]
       end
@@ -774,12 +775,14 @@ RSpec.describe DbSchema::Runner do
         subject.run!
 
         expect(extensions).to eq([
-          DbSchema::Definitions::Extension.new(:ltree)
+          DbSchema::Definitions::Extension.new(:ltree),
+          DbSchema::Definitions::Extension.new(:'uuid-ossp')
         ])
       end
 
       after(:each) do
         database.run('DROP EXTENSION ltree')
+        database.run('DROP EXTENSION "uuid-ossp"')
       end
     end
 


### PR DESCRIPTION
Support for Postgres extensions and their data types.

* [x] CREATE EXTENSION
* [x] DROP EXTENSION
* [x] data types from extensions:
  * [x] `chkpass`
  * [x] `citext`
  * [x] `cube`
  * [x] `hstore`
  * [x] `isn`
  * [ ] `lo`
  * [x] `seg`
  * [x] `ltree`
* [x] describe extensions DSL and new data types in the readme