### PR TITLE
New operations for changing values of an enum type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,9 @@ If your production setup doesn't include multiple workers starting simultaneousl
 ## DSL
 
 Database schema is defined with a block passed to `DbSchema.describe` method.
-This block receives a `db` object on which you can call `#table` to define a table
-and `#enum` to define a custom enum type. Everything that belongs to a specific table
-is described in a block passed to `#table`.
+This block receives a `db` object on which you can call `#table` to define a table,
+`#enum` to define a custom enum type and `#extension` to plug a Postgres extension into your database.
+Everything that belongs to a specific table is described in a block passed to `#table`.
 
 ``` ruby
 DbSchema.describe do |db|
@@ -500,13 +500,15 @@ db.table :users do |t|
 end
 ```
 
-After the enum type is created, you can add more values to it. They don't have to appear in the end of the values list - you can add new values to the middle or even to the beginning of the list:
+Arrays of enums are also supported - they are described just like arrays of any other element type:
 
 ``` ruby
-db.enum :user_status, [:guest, :registered, :sent_confirmation_email, :confirmed_email, :subscriber]
-```
+db.enum :user_role, [:user, :manager, :admin]
 
-Reordering and deleting values from enum types is not supported.
+db.table :users do |t|
+  t.array :roles, of: :user_role, default: '{user}'
+end
+```
 
 ### Extensions
 

--- a/lib/db_schema.rb
+++ b/lib/db_schema.rb
@@ -18,7 +18,7 @@ module DbSchema
     def describe(&block)
       desired_schema = DSL.new(block).schema
       validate(desired_schema)
-      Normalizer.normalize_tables(desired_schema)
+      Normalizer.new(desired_schema).normalize_tables
 
       actual_schema = Reader.read_schema
       changes = Changes.between(desired_schema, actual_schema)

--- a/lib/db_schema/awesome_print.rb
+++ b/lib/db_schema/awesome_print.rb
@@ -69,13 +69,14 @@ if defined?(AwesomePrint)
         when ::DbSchema::Changes::DropForeignKey
           :dbschema_drop_foreign_key
         when ::DbSchema::Changes::CreateEnum
-          :dbschema_enum
+          :dbschema_create_enum
         when ::DbSchema::Changes::DropEnum
           :dbschema_column_operation
         when ::DbSchema::Changes::AlterEnumValues
           :dbschema_alter_enum_values
-        when ::DbSchema::Changes::CreateExtension,
-             ::DbSchema::Changes::DropExtension
+        when ::DbSchema::Changes::CreateExtension
+          :dbschema_create_extension
+        when ::DbSchema::Changes::DropExtension
           :dbschema_column_operation
         else
           cast_without_dbschema(object, type)
@@ -266,6 +267,14 @@ if defined?(AwesomePrint)
         "#<DbSchema::Changes::DropForeignKey #{object.fkey_name.ai} on #{object.table_name.ai}>"
       end
 
+      def awesome_dbschema_create_enum(object)
+        values = object.enum.values.map do |value|
+          colorize(value.to_s, :string)
+        end.join(', ')
+
+        "#<#{object.class} #{object.enum.name.ai} (#{values})>"
+      end
+
       def awesome_dbschema_column_operation(object)
         "#<#{object.class} #{object.name.ai}>"
       end
@@ -276,6 +285,10 @@ if defined?(AwesomePrint)
         end.join(', ')
 
         "#<DbSchema::Changes::AlterEnumValues #{object.enum_name.ai} to (#{values})>"
+      end
+
+      def awesome_dbschema_create_extension(object)
+        "#<#{object.class} #{object.extension.name.ai}>"
       end
 
       def format_dbschema_fields(fields)

--- a/lib/db_schema/awesome_print.rb
+++ b/lib/db_schema/awesome_print.rb
@@ -72,6 +72,8 @@ if defined?(AwesomePrint)
           :dbschema_column_operation
         when ::DbSchema::Changes::AddValueToEnum
           :dbschema_add_value_to_enum
+        when ::DbSchema::Changes::AlterEnumValues
+          :dbschema_alter_enum_values
         when ::DbSchema::Changes::CreateExtension,
              ::DbSchema::Changes::DropExtension
           :dbschema_column_operation
@@ -258,6 +260,14 @@ if defined?(AwesomePrint)
         before = " before #{object.before.ai}" unless object.add_to_the_end?
 
         "#<DbSchema::Changes::AddValueToEnum #{object.new_value.ai} to #{object.enum_name.ai}#{before}>"
+      end
+
+      def awesome_dbschema_alter_enum_values(object)
+        values = object.new_values.map do |value|
+          colorize(value.to_s, :string)
+        end.join(', ')
+
+        "#<DbSchema::Changes::AlterEnumValues #{object.enum_name.ai} to (#{values})>"
       end
 
       def format_dbschema_fields(fields)

--- a/lib/db_schema/awesome_print.rb
+++ b/lib/db_schema/awesome_print.rb
@@ -209,12 +209,7 @@ if defined?(AwesomePrint)
       end
 
       def awesome_dbschema_alter_table(object)
-        data = ["fields: #{object.fields.ai}"]
-        data << "indices: #{object.indices.ai}" if object.indices.any?
-        data << "checks: #{object.checks.ai}" if object.checks.any?
-
-        data_string = indent_lines(data.join(', '))
-        "#<DbSchema::Changes::AlterTable #{object.name.ai} #{data_string}>"
+        "#<DbSchema::Changes::AlterTable #{object.table_name.ai} #{indent_lines(object.changes.ai)}>"
       end
 
       def awesome_dbschema_create_column(object)

--- a/lib/db_schema/awesome_print.rb
+++ b/lib/db_schema/awesome_print.rb
@@ -196,12 +196,12 @@ if defined?(AwesomePrint)
       end
 
       def awesome_dbschema_create_table(object)
-        data = ["fields: #{object.fields.ai}"]
-        data << "indices: #{object.indices.ai}" if object.indices.any?
-        data << "checks: #{object.checks.ai}" if object.checks.any?
+        data = ["fields: #{object.table.fields.ai}"]
+        data << "indices: #{object.table.indices.ai}" if object.table.indices.any?
+        data << "checks: #{object.table.checks.ai}" if object.table.checks.any?
 
         data_string = indent_lines(data.join(', '))
-        "#<DbSchema::Changes::CreateTable #{object.name.ai} #{data_string}>"
+        "#<DbSchema::Changes::CreateTable #{object.table.name.ai} #{data_string}>"
       end
 
       def awesome_dbschema_drop_table(object)

--- a/lib/db_schema/awesome_print.rb
+++ b/lib/db_schema/awesome_print.rb
@@ -57,11 +57,11 @@ if defined?(AwesomePrint)
         when ::DbSchema::Changes::AlterColumnDefault
           :dbschema_alter_column_default
         when ::DbSchema::Changes::CreateIndex
-          :dbschema_index
+          :dbschema_create_index
         when ::DbSchema::Changes::DropIndex
           :dbschema_column_operation
         when ::DbSchema::Changes::CreateCheckConstraint
-          :dbschema_check_constraint
+          :dbschema_create_check_constraint
         when ::DbSchema::Changes::DropCheckConstraint
           :dbschema_column_operation
         when ::DbSchema::Changes::CreateForeignKey
@@ -241,6 +241,21 @@ if defined?(AwesomePrint)
         end
 
         "#<DbSchema::Changes::AlterColumnDefault #{object.name.ai}, #{new_default}>"
+      end
+
+      def awesome_dbschema_create_index(object)
+        columns = format_dbschema_fields(object.index.columns)
+        using = ' using ' + colorize(object.index.type.to_s, :symbol) unless object.index.btree?
+
+        data = [nil]
+        data << colorize('unique', :nilclass) if object.index.unique?
+        data << colorize('condition: ', :symbol) + object.index.condition.ai unless object.index.condition.nil?
+
+        "#<#{object.class} #{object.index.name.ai} on #{columns}#{using}#{data.join(', ')}>"
+      end
+
+      def awesome_dbschema_create_check_constraint(object)
+        "#<#{object.class} #{object.check.name.ai} #{object.check.condition.ai}>"
       end
 
       def awesome_dbschema_create_foreign_key(object)

--- a/lib/db_schema/awesome_print.rb
+++ b/lib/db_schema/awesome_print.rb
@@ -70,8 +70,6 @@ if defined?(AwesomePrint)
           :dbschema_enum
         when ::DbSchema::Changes::DropEnum
           :dbschema_column_operation
-        when ::DbSchema::Changes::AddValueToEnum
-          :dbschema_add_value_to_enum
         when ::DbSchema::Changes::AlterEnumValues
           :dbschema_alter_enum_values
         when ::DbSchema::Changes::CreateExtension,
@@ -254,12 +252,6 @@ if defined?(AwesomePrint)
 
       def awesome_dbschema_column_operation(object)
         "#<#{object.class} #{object.name.ai}>"
-      end
-
-      def awesome_dbschema_add_value_to_enum(object)
-        before = " before #{object.before.ai}" unless object.add_to_the_end?
-
-        "#<DbSchema::Changes::AddValueToEnum #{object.new_value.ai} to #{object.enum_name.ai}#{before}>"
       end
 
       def awesome_dbschema_alter_enum_values(object)

--- a/lib/db_schema/awesome_print.rb
+++ b/lib/db_schema/awesome_print.rb
@@ -15,6 +15,8 @@ if defined?(AwesomePrint)
         case object
         when ::DbSchema::Definitions::Schema
           :dbschema_schema
+        when ::DbSchema::Definitions::NullTable
+          :dbschema_null_table
         when ::DbSchema::Definitions::Table
           :dbschema_table
         when ::DbSchema::Definitions::Field::Custom
@@ -98,6 +100,10 @@ if defined?(AwesomePrint)
 
         data_string = indent_lines(data.join(', '))
         "#<DbSchema::Definitions::Table #{object.name.ai} #{data_string}>"
+      end
+
+      def awesome_dbschema_null_table(object)
+        '#<DbSchema::Definitions::NullTable>'
       end
 
       def awesome_dbschema_field(object)

--- a/lib/db_schema/changes.rb
+++ b/lib/db_schema/changes.rb
@@ -66,8 +66,6 @@ module DbSchema
                 # TODO: fix this mess
                 new_default = if (new_table = desired_schema.tables.find { |new_table| new_table.name == table.name }) && (new_field = new_table.fields.find { |new_field| new_field.name == field.name })
                   new_field.default
-                else
-                  field.default
                 end
 
                 [table.name, field.name, new_default]

--- a/lib/db_schema/changes.rb
+++ b/lib/db_schema/changes.rb
@@ -63,9 +63,8 @@ module DbSchema
               table.fields.select do |field|
                 field.type == enum_name
               end.map do |field|
-                # TODO: fix this mess
-                new_default = if (new_table = desired_schema.tables.find { |new_table| new_table.name == table.name }) && (new_field = new_table.fields.find { |new_field| new_field.name == field.name })
-                  new_field.default
+                if desired_field = desired_schema[table.name][field.name]
+                  new_default = desired_field.default
                 end
 
                 [table.name, field.name, new_default]

--- a/lib/db_schema/changes.rb
+++ b/lib/db_schema/changes.rb
@@ -48,7 +48,7 @@ module DbSchema
           actual  = actual_schema.enums.find  { |enum| enum.name == enum_name }
 
           if desired && !actual
-            changes << CreateEnum.new(enum_name, desired.values)
+            changes << CreateEnum.new(desired)
           elsif actual && !desired
             changes << DropEnum.new(enum_name)
           elsif actual != desired
@@ -78,7 +78,7 @@ module DbSchema
         end
 
         extension_changes = (desired_schema.extensions - actual_schema.extensions).map do |extension|
-          CreateExtension.new(extension.name)
+          CreateExtension.new(extension)
         end + (actual_schema.extensions - desired_schema.extensions).map do |extension|
           DropExtension.new(extension.name)
         end
@@ -337,7 +337,13 @@ module DbSchema
       end
     end
 
-    class CreateEnum < Definitions::Enum
+    class CreateEnum
+      include Dry::Equalizer(:enum)
+      attr_reader :enum
+
+      def initialize(enum)
+        @enum = enum
+      end
     end
 
     class DropEnum < ColumnOperation
@@ -354,7 +360,13 @@ module DbSchema
       end
     end
 
-    class CreateExtension < Definitions::Extension
+    class CreateExtension
+      include Dry::Equalizer(:extension)
+      attr_reader :extension
+
+      def initialize(extension)
+        @extension = extension
+      end
     end
 
     class DropExtension < ColumnOperation

--- a/lib/db_schema/changes.rb
+++ b/lib/db_schema/changes.rb
@@ -61,13 +61,22 @@ module DbSchema
           elsif actual != desired
             fields = actual_schema.tables.flat_map do |table|
               table.fields.select do |field|
-                field.type == enum_name
+                if field.type == :array
+                  field.attributes[:element_type] == enum_name
+                else
+                  field.type == enum_name
+                end
               end.map do |field|
                 if desired_field = desired_schema[table.name][field.name]
                   new_default = desired_field.default
                 end
 
-                [table.name, field.name, new_default]
+                {
+                  table_name:  table.name,
+                  field_name:  field.name,
+                  new_default: new_default,
+                  array:       field.type == :array
+                }
               end
             end
 

--- a/lib/db_schema/changes.rb
+++ b/lib/db_schema/changes.rb
@@ -33,9 +33,7 @@ module DbSchema
             if field_operations.any? || index_operations.any? || check_operations.any?
               changes << AlterTable.new(
                 table_name,
-                fields:  field_operations,
-                indices: index_operations,
-                checks:  check_operations
+                field_operations + index_operations + check_operations
               )
             end
 
@@ -234,14 +232,12 @@ module DbSchema
     end
 
     class AlterTable
-      include Dry::Equalizer(:name, :fields, :indices, :checks)
-      attr_reader :name, :fields, :indices, :checks
+      include Dry::Equalizer(:table_name, :changes)
+      attr_reader :table_name, :changes
 
-      def initialize(name, fields: [], indices: [], checks: [])
-        @name    = name
-        @fields  = fields
-        @indices = indices
-        @checks  = checks
+      def initialize(table_name, changes)
+        @table_name = table_name
+        @changes    = changes
       end
     end
 

--- a/lib/db_schema/changes.rb
+++ b/lib/db_schema/changes.rb
@@ -60,7 +60,11 @@ module DbSchema
             changes << DropEnum.new(enum_name)
           elsif actual != desired
             fields = actual_schema.tables.flat_map do |table|
-              table.fields.select { |field| field.type == enum_name }
+              table.fields.select do |field|
+                field.type == enum_name
+              end.map do |field|
+                [table.name, field.name, field.default]
+              end
             end
 
             changes << AlterEnumValues.new(enum_name, desired.values, fields)

--- a/lib/db_schema/changes.rb
+++ b/lib/db_schema/changes.rb
@@ -138,24 +138,12 @@ module DbSchema
           actual  = actual_indices.find  { |index| index.name == index_name }
 
           if desired && !actual
-            table_changes << CreateIndex.new(
-              name:      index_name,
-              columns:   desired.columns,
-              unique:    desired.unique?,
-              type:      desired.type,
-              condition: desired.condition
-            )
+            table_changes << CreateIndex.new(desired)
           elsif actual && !desired
             table_changes << DropIndex.new(index_name)
           elsif actual != desired
             table_changes << DropIndex.new(index_name)
-            table_changes << CreateIndex.new(
-              name:      index_name,
-              columns:   desired.columns,
-              unique:    desired.unique?,
-              type:      desired.type,
-              condition: desired.condition
-            )
+            table_changes << CreateIndex.new(desired)
           end
         end
       end
@@ -168,18 +156,12 @@ module DbSchema
           actual  = actual_checks.find  { |check| check.name == check_name }
 
           if desired && !actual
-            table_changes << CreateCheckConstraint.new(
-              name:      check_name,
-              condition: desired.condition
-            )
+            table_changes << CreateCheckConstraint.new(desired)
           elsif actual && !desired
             table_changes << DropCheckConstraint.new(check_name)
           elsif actual != desired
             table_changes << DropCheckConstraint.new(check_name)
-            table_changes << CreateCheckConstraint.new(
-              name:      check_name,
-              condition: desired.condition
-            )
+            table_changes << CreateCheckConstraint.new(desired)
           end
         end
       end
@@ -321,13 +303,25 @@ module DbSchema
       end
     end
 
-    class CreateIndex < Definitions::Index
+    class CreateIndex
+      include Dry::Equalizer(:index)
+      attr_reader :index
+
+      def initialize(index)
+        @index = index
+      end
     end
 
     class DropIndex < ColumnOperation
     end
 
-    class CreateCheckConstraint < Definitions::CheckConstraint
+    class CreateCheckConstraint
+      include Dry::Equalizer(:check)
+      attr_reader :check
+
+      def initialize(check)
+        @check = check
+      end
     end
 
     class DropCheckConstraint < ColumnOperation

--- a/lib/db_schema/changes.rb
+++ b/lib/db_schema/changes.rb
@@ -12,12 +12,7 @@ module DbSchema
           actual  = actual_schema.tables.find  { |table| table.name == table_name }
 
           if desired && !actual
-            changes << CreateTable.new(
-              table_name,
-              fields:  desired.fields,
-              indices: desired.indices,
-              checks:  desired.checks
-            )
+            changes << CreateTable.new(desired)
 
             fkey_operations = desired.foreign_keys.map do |fkey|
               CreateForeignKey.new(table_name, fkey)
@@ -221,14 +216,11 @@ module DbSchema
     end
 
     class CreateTable
-      include Dry::Equalizer(:name, :fields, :indices, :checks)
-      attr_reader :name, :fields, :indices, :checks
+      include Dry::Equalizer(:table)
+      attr_reader :table
 
-      def initialize(name, fields: [], indices: [], checks: [])
-        @name    = name
-        @fields  = fields
-        @indices = indices
-        @checks  = checks
+      def initialize(table)
+        @table = table
       end
     end
 

--- a/lib/db_schema/changes.rb
+++ b/lib/db_schema/changes.rb
@@ -54,7 +54,7 @@ module DbSchema
           elsif actual != desired
             fields = actual_schema.tables.flat_map do |table|
               table.fields.select do |field|
-                if field.type == :array
+                if field.array?
                   field.attributes[:element_type] == enum_name
                 else
                   field.type == enum_name
@@ -68,7 +68,7 @@ module DbSchema
                   table_name:  table.name,
                   field_name:  field.name,
                   new_default: new_default,
-                  array:       field.type == :array
+                  array:       field.array?
                 }
               end
             end

--- a/lib/db_schema/changes.rb
+++ b/lib/db_schema/changes.rb
@@ -63,7 +63,14 @@ module DbSchema
               table.fields.select do |field|
                 field.type == enum_name
               end.map do |field|
-                [table.name, field.name, field.default]
+                # TODO: fix this mess
+                new_default = if (new_table = desired_schema.tables.find { |new_table| new_table.name == table.name }) && (new_field = new_table.fields.find { |new_field| new_field.name == field.name })
+                  new_field.default
+                else
+                  field.default
+                end
+
+                [table.name, field.name, new_default]
               end
             end
 

--- a/lib/db_schema/changes.rb
+++ b/lib/db_schema/changes.rb
@@ -358,22 +358,6 @@ module DbSchema
     class DropEnum < ColumnOperation
     end
 
-    # TODO: remove this class after refactoring Runner
-    class AddValueToEnum
-      include Dry::Equalizer(:enum_name, :new_value, :before)
-      attr_reader :enum_name, :new_value, :before
-
-      def initialize(enum_name, new_value, before: nil)
-        @enum_name = enum_name
-        @new_value = new_value
-        @before    = before
-      end
-
-      def add_to_the_end?
-        before.nil?
-      end
-    end
-
     class AlterEnumValues
       include Dry::Equalizer(:enum_name, :new_values, :enum_fields)
       attr_reader :enum_name, :new_values, :enum_fields

--- a/lib/db_schema/changes.rb
+++ b/lib/db_schema/changes.rb
@@ -173,23 +173,13 @@ module DbSchema
           desired = desired_foreign_keys.find { |key| key.name == key_name }
           actual  = actual_foreign_keys.find  { |key| key.name == key_name }
 
-          foreign_key = Definitions::ForeignKey.new(
-            name:       key_name,
-            fields:     desired.fields,
-            table:      desired.table,
-            keys:       desired.keys,
-            on_delete:  desired.on_delete,
-            on_update:  desired.on_update,
-            deferrable: desired.deferrable?
-          ) if desired
-
           if desired && !actual
-            table_changes << CreateForeignKey.new(table_name, foreign_key)
+            table_changes << CreateForeignKey.new(table_name, desired)
           elsif actual && !desired
             table_changes << DropForeignKey.new(table_name, key_name)
           elsif actual != desired
             table_changes << DropForeignKey.new(table_name, key_name)
-            table_changes << CreateForeignKey.new(table_name, foreign_key)
+            table_changes << CreateForeignKey.new(table_name, desired)
           end
         end
       end

--- a/lib/db_schema/definitions.rb
+++ b/lib/db_schema/definitions.rb
@@ -39,6 +39,46 @@ module DbSchema
       def [](field_name)
         fields.find { |field| field.name == field_name }
       end
+
+      def with_name(new_name)
+        Table.new(
+          new_name,
+          fields:       fields,
+          indices:      indices,
+          checks:       checks,
+          foreign_keys: foreign_keys
+        )
+      end
+
+      def with_fields(new_fields)
+        Table.new(
+          name,
+          fields:       new_fields,
+          indices:      indices,
+          checks:       checks,
+          foreign_keys: foreign_keys
+        )
+      end
+
+      def with_indices(new_indices)
+        Table.new(
+          name,
+          fields:       fields,
+          indices:      new_indices,
+          checks:       checks,
+          foreign_keys: foreign_keys
+        )
+      end
+
+      def with_foreign_keys(new_foreign_keys)
+        Table.new(
+          name,
+          fields:       fields,
+          indices:      indices,
+          checks:       checks,
+          foreign_keys: new_foreign_keys
+        )
+      end
     end
 
     class NullTable < Table

--- a/lib/db_schema/definitions.rb
+++ b/lib/db_schema/definitions.rb
@@ -77,6 +77,16 @@ module DbSchema
         !condition.nil? || columns.any?(&:expression?)
       end
 
+      def with_name(new_name)
+        Index.new(
+          name:      new_name,
+          columns:   columns,
+          unique:    unique?,
+          type:      type,
+          condition: condition
+        )
+      end
+
       class Column
         include Dry::Equalizer(:name, :order, :nulls)
         attr_reader :name, :order, :nulls

--- a/lib/db_schema/definitions.rb
+++ b/lib/db_schema/definitions.rb
@@ -12,6 +12,10 @@ module DbSchema
         @enums      = enums
         @extensions = extensions
       end
+
+      def [](table_name)
+        tables.find { |table| table.name == table_name } || NullTable.new
+      end
     end
 
     class Table
@@ -31,6 +35,14 @@ module DbSchema
           indices.any?(&:has_expressions?) ||
           checks.any?
       end
+
+      def [](field_name)
+        fields.find { |field| field.name == field_name }
+      end
+    end
+
+    class NullTable < Table
+      def initialize; end
     end
 
     class Index

--- a/lib/db_schema/definitions.rb
+++ b/lib/db_schema/definitions.rb
@@ -235,6 +235,10 @@ module DbSchema
         @name   = name
         @values = values
       end
+
+      def with_name(new_name)
+        Enum.new(new_name, values)
+      end
     end
 
     class Extension

--- a/lib/db_schema/definitions/field/array.rb
+++ b/lib/db_schema/definitions/field/array.rb
@@ -10,7 +10,7 @@ module DbSchema
         end
 
         def attributes
-          super.merge(element_type: @attributes[:element_type].type)
+          super.merge(element_type: element_type.type)
         end
 
         def array?

--- a/lib/db_schema/definitions/field/array.rb
+++ b/lib/db_schema/definitions/field/array.rb
@@ -3,15 +3,14 @@ module DbSchema
     module Field
       class Array < Base
         register :array
-        attr_reader :element_type
 
-        def initialize(name, of:, **options)
-          super(name, **options)
-          @element_type = Field.type_class_for(of)
+        def initialize(name, **options)
+          type_class = Field.type_class_for(options[:element_type])
+          super(name, **options.merge(element_type: type_class))
         end
 
         def attributes
-          super.merge(element_type: element_type.type)
+          super.merge(element_type: @attributes[:element_type].type)
         end
       end
     end

--- a/lib/db_schema/definitions/field/array.rb
+++ b/lib/db_schema/definitions/field/array.rb
@@ -12,6 +12,18 @@ module DbSchema
         def attributes
           super.merge(element_type: @attributes[:element_type].type)
         end
+
+        def array?
+          true
+        end
+
+        def element_type
+          @attributes[:element_type]
+        end
+
+        def custom_element_type?
+          element_type.superclass == Custom
+        end
       end
     end
   end

--- a/lib/db_schema/definitions/field/base.rb
+++ b/lib/db_schema/definitions/field/base.rb
@@ -25,6 +25,14 @@ module DbSchema
           default.is_a?(Symbol)
         end
 
+        def array?
+          false
+        end
+
+        def custom?
+          false
+        end
+
         def options
           attributes.tap do |options|
             options[:null] = false unless null?
@@ -46,6 +54,14 @@ module DbSchema
 
         def type
           self.class.type
+        end
+
+        def with_type(new_type)
+          Field.build(name, new_type, **options, primary_key: primary_key?)
+        end
+
+        def with_attribute(attr_name, attr_value)
+          Field.build(name, type, **options, primary_key: primary_key?, attr_name => attr_value)
         end
 
         class << self

--- a/lib/db_schema/definitions/field/custom.rb
+++ b/lib/db_schema/definitions/field/custom.rb
@@ -6,7 +6,7 @@ module DbSchema
           def class_for(type_name)
             raise ArgumentError if type_name.nil?
 
-            Class.new(self) do
+            custom_types[type_name] ||= Class.new(self) do
               define_method :type do
                 type_name
               end
@@ -15,6 +15,11 @@ module DbSchema
                 type_name
               end
             end
+          end
+
+        private
+          def custom_types
+            @custom_types ||= {}
           end
         end
       end

--- a/lib/db_schema/definitions/field/custom.rb
+++ b/lib/db_schema/definitions/field/custom.rb
@@ -14,6 +14,10 @@ module DbSchema
               define_singleton_method :type do
                 type_name
               end
+
+              define_method :custom? do
+                true
+              end
             end
           end
 

--- a/lib/db_schema/dsl.rb
+++ b/lib/db_schema/dsl.rb
@@ -42,9 +42,15 @@ module DbSchema
       end
 
       DbSchema::Definitions::Field.registry.keys.each do |type|
+        next if type == :array
+
         define_method(type) do |name, **options|
           field(name, type, options)
         end
+      end
+
+      def array(name, of:, **options)
+        field(name, :array, element_type: of, **options)
       end
 
       def method_missing(method_name, name, *args, &block)

--- a/lib/db_schema/normalizer.rb
+++ b/lib/db_schema/normalizer.rb
@@ -27,10 +27,11 @@ module DbSchema
 
   private
     def create_extensions!
-      (schema.extensions - Reader.read_extensions).each do |extension|
-        operation = Changes::CreateExtension.new(extension.name)
-        Runner.new([operation]).run!
+      operations = (schema.extensions - Reader.read_extensions).map do |extension|
+        Changes::CreateExtension.new(extension.name)
       end
+
+      Runner.new(operations).run!
     end
 
     def create_enums!

--- a/lib/db_schema/normalizer.rb
+++ b/lib/db_schema/normalizer.rb
@@ -2,118 +2,164 @@ require 'digest/md5'
 
 module DbSchema
   class Normalizer
-    attr_reader :table
+    attr_reader :schema
 
-    class << self
-      def normalize_tables(schema)
-        DbSchema.connection.transaction do
-          create_extensions!(schema.extensions)
-          create_enums!(schema.enums)
+    def initialize(schema)
+      @schema = schema
+    end
 
-          schema.tables = schema.tables.map do |table|
-            if table.has_expressions?
-              new(table).normalized_table
-            else
-              table
-            end
+    def normalize_tables
+      DbSchema.connection.transaction do
+        create_extensions!
+        create_enums!
+
+        schema.tables = schema.tables.map do |table|
+          if table.has_expressions?
+            Table.new(table, hash).normalized_table
+          else
+            table
           end
-
-          raise Sequel::Rollback
         end
+
+        raise Sequel::Rollback
       end
-
-    private
-      def create_extensions!(extensions)
-        (extensions - DbSchema::Reader.read_extensions).each do |extension|
-          operation = DbSchema::Changes::CreateExtension.new(extension.name)
-          DbSchema::Runner.new([operation]).run!
-        end
-      end
-
-      def create_enums!(enums)
-        existing_enums_names = DbSchema::Reader.read_enums.map(&:name)
-        enums.each do |enum|
-          next if existing_enums_names.include?(enum.name)
-
-          operation = DbSchema::Changes::CreateEnum.new(enum.name, enum.values)
-          DbSchema::Runner.new([operation]).run!
-        end
-      end
-    end
-
-    def initialize(table)
-      @table = table
-    end
-
-    def normalized_table
-      create_temporary_table!
-      read_temporary_table
     end
 
   private
-    def create_temporary_table!
-      operation = Changes::CreateTable.new(
-        temporary_table_name,
-        fields:  table.fields,
-        indices: rename_indices(table.indices),
-        checks:  table.checks
-      )
-
-      Runner.new([operation]).run!
-    end
-
-    def read_temporary_table
-      temporary_table = Reader.read_table(temporary_table_name)
-
-      Definitions::Table.new(
-        remove_hash(temporary_table.name),
-        fields:       temporary_table.fields,
-        indices:      rename_indices_back(temporary_table.indices),
-        checks:       temporary_table.checks,
-        foreign_keys: table.foreign_keys
-      )
-    end
-
-    def rename_indices(indices)
-      indices.map do |index|
-        Definitions::Index.new(
-          name:      append_hash(index.name),
-          columns:   index.columns,
-          unique:    index.unique?,
-          type:      index.type,
-          condition: index.condition
-        )
+    def create_extensions!
+      (schema.extensions - Reader.read_extensions).each do |extension|
+        operation = Changes::CreateExtension.new(extension.name)
+        Runner.new([operation]).run!
       end
     end
 
-    def rename_indices_back(indices)
-      indices.map do |index|
-        Definitions::Index.new(
-          name:      remove_hash(index.name),
-          columns:   index.columns,
-          unique:    index.unique?,
-          type:      index.type,
-          condition: index.condition
-        )
+    def create_enums!
+      operations = schema.enums.map do |enum|
+        Changes::CreateEnum.new(append_hash(enum.name), enum.values)
       end
-    end
 
-    def temporary_table_name
-      append_hash(table.name)
+      Runner.new(operations).run!
     end
 
     def append_hash(name)
       "#{name}_#{hash}"
     end
 
-    def remove_hash(name)
-      name.to_s.sub(/_#{Regexp.escape(hash)}$/, '').to_sym
-    end
-
     def hash
       @hash ||= begin
-        names = [table.name] + table.fields.map(&:name) + table.indices.map(&:name) + table.checks.map(&:name)
+        names = schema.tables.flat_map do |table|
+          [table.name] + table.fields.map(&:name) + table.indices.map(&:name) + table.checks.map(&:name)
+        end
+
         Digest::MD5.hexdigest(names.join(','))[0..9]
+      end
+    end
+
+    class Table
+      attr_reader :table, :hash
+
+      def initialize(table, hash)
+        @table = table
+        @hash  = hash
+      end
+
+      def normalized_table
+        create_temporary_table!
+        read_temporary_table
+      end
+
+    private
+      def create_temporary_table!
+        operation = Changes::CreateTable.new(
+          temporary_table_name,
+          fields:  rename_types(table.fields),
+          indices: rename_indices(table.indices),
+          checks:  table.checks
+        )
+
+        Runner.new([operation]).run!
+      end
+
+      def read_temporary_table
+        temporary_table = Reader.read_table(temporary_table_name)
+
+        Definitions::Table.new(
+          remove_hash(temporary_table.name),
+          fields:       rename_types_back(temporary_table.fields),
+          indices:      rename_indices_back(temporary_table.indices),
+          checks:       temporary_table.checks,
+          foreign_keys: table.foreign_keys
+        )
+      end
+
+      def rename_types(fields)
+        fields.map do |field|
+          type = if field.is_a?(Definitions::Field::Custom)
+            append_hash(field.type)
+          else
+            field.type
+          end
+
+          Definitions::Field.build(
+            field.name,
+            type,
+            primary_key: field.primary_key?,
+            **field.options
+          )
+        end
+      end
+
+      def rename_types_back(fields)
+        fields.map do |field|
+          type = if field.is_a?(Definitions::Field::Custom)
+            remove_hash(field.type)
+          else
+            field.type
+          end
+
+          Definitions::Field.build(
+            field.name,
+            type,
+            primary_key: field.primary_key?,
+            **field.options
+          )
+        end
+      end
+
+      def rename_indices(indices)
+        indices.map do |index|
+          Definitions::Index.new(
+            name:      append_hash(index.name),
+            columns:   index.columns,
+            unique:    index.unique?,
+            type:      index.type,
+            condition: index.condition
+          )
+        end
+      end
+
+      def rename_indices_back(indices)
+        indices.map do |index|
+          Definitions::Index.new(
+            name:      remove_hash(index.name),
+            columns:   index.columns,
+            unique:    index.unique?,
+            type:      index.type,
+            condition: index.condition
+          )
+        end
+      end
+
+      def temporary_table_name
+        append_hash(table.name)
+      end
+
+      def append_hash(name)
+        "#{name}_#{hash}"
+      end
+
+      def remove_hash(name)
+        name.to_s.sub(/_#{Regexp.escape(hash)}$/, '').to_sym
       end
     end
   end

--- a/lib/db_schema/normalizer.rb
+++ b/lib/db_schema/normalizer.rb
@@ -28,7 +28,7 @@ module DbSchema
   private
     def create_extensions!
       operations = (schema.extensions - Reader.read_extensions).map do |extension|
-        Changes::CreateExtension.new(extension.name)
+        Changes::CreateExtension.new(extension)
       end
 
       Runner.new(operations).run!
@@ -36,7 +36,7 @@ module DbSchema
 
     def create_enums!
       operations = schema.enums.map do |enum|
-        Changes::CreateEnum.new(append_hash(enum.name), enum.values)
+        Changes::CreateEnum.new(enum.with_name(append_hash(enum.name)))
       end
 
       Runner.new(operations).run!

--- a/lib/db_schema/normalizer.rb
+++ b/lib/db_schema/normalizer.rb
@@ -119,25 +119,13 @@ module DbSchema
 
       def rename_indices(indices)
         indices.map do |index|
-          Definitions::Index.new(
-            name:      append_hash(index.name),
-            columns:   index.columns,
-            unique:    index.unique?,
-            type:      index.type,
-            condition: index.condition
-          )
+          index.with_name(append_hash(index.name))
         end
       end
 
       def rename_indices_back(indices)
         indices.map do |index|
-          Definitions::Index.new(
-            name:      remove_hash(index.name),
-            columns:   index.columns,
-            unique:    index.unique?,
-            type:      index.type,
-            condition: index.condition
-          )
+          index.with_name(remove_hash(index.name))
         end
       end
 

--- a/lib/db_schema/normalizer.rb
+++ b/lib/db_schema/normalizer.rb
@@ -95,35 +95,65 @@ module DbSchema
 
       def rename_types(fields)
         fields.map do |field|
-          type = if field.is_a?(Definitions::Field::Custom)
-            append_hash(field.type)
-          else
-            field.type
-          end
+          if field.is_a?(Definitions::Field::Array)
+            element_type = Definitions::Field.type_class_for(field.attributes[:element_type])
 
-          Definitions::Field.build(
-            field.name,
-            type,
-            primary_key: field.primary_key?,
-            **field.options
-          )
+            if element_type.superclass == Definitions::Field::Custom
+              Definitions::Field::Array.new(
+                field.name,
+                **field.options,
+                element_type: append_hash(field.attributes[:element_type]).to_sym,
+                primary_key: field.primary_key?
+              )
+            else
+              field
+            end
+          else
+            type = if field.is_a?(Definitions::Field::Custom)
+              append_hash(field.type)
+            else
+              field.type
+            end
+
+            Definitions::Field.build(
+              field.name,
+              type,
+              primary_key: field.primary_key?,
+              **field.options
+            )
+          end
         end
       end
 
       def rename_types_back(fields)
         fields.map do |field|
-          type = if field.is_a?(Definitions::Field::Custom)
-            remove_hash(field.type)
-          else
-            field.type
-          end
+          if field.is_a?(Definitions::Field::Array)
+            element_type = Definitions::Field.type_class_for(field.attributes[:element_type])
 
-          Definitions::Field.build(
-            field.name,
-            type,
-            primary_key: field.primary_key?,
-            **field.options
-          )
+            if element_type.superclass == Definitions::Field::Custom
+              Definitions::Field::Array.new(
+                field.name,
+                **field.options,
+                element_type: remove_hash(field.attributes[:element_type]).to_sym,
+                primary_key: field.primary_key?
+              )
+            else
+              field
+            end
+          else
+            type = if field.is_a?(Definitions::Field::Custom)
+              remove_hash(field.type)
+            else
+              field.type
+            end
+
+            Definitions::Field.build(
+              field.name,
+              type,
+              primary_key: field.primary_key?,
+              **field.options
+            )
+          end
         end
       end
 

--- a/lib/db_schema/normalizer.rb
+++ b/lib/db_schema/normalizer.rb
@@ -95,64 +95,24 @@ module DbSchema
 
       def rename_types(fields)
         fields.map do |field|
-          if field.is_a?(Definitions::Field::Array)
-            element_type = Definitions::Field.type_class_for(field.attributes[:element_type])
-
-            if element_type.superclass == Definitions::Field::Custom
-              Definitions::Field::Array.new(
-                field.name,
-                **field.options,
-                element_type: append_hash(field.attributes[:element_type]).to_sym,
-                primary_key: field.primary_key?
-              )
-            else
-              field
-            end
+          if field.custom?
+            field.with_type(append_hash(field.type))
+          elsif field.array? && field.custom_element_type?
+            field.with_attribute(:element_type, append_hash(field.element_type.type).to_sym)
           else
-            type = if field.is_a?(Definitions::Field::Custom)
-              append_hash(field.type)
-            else
-              field.type
-            end
-
-            Definitions::Field.build(
-              field.name,
-              type,
-              primary_key: field.primary_key?,
-              **field.options
-            )
+            field
           end
         end
       end
 
       def rename_types_back(fields)
         fields.map do |field|
-          if field.is_a?(Definitions::Field::Array)
-            element_type = Definitions::Field.type_class_for(field.attributes[:element_type])
-
-            if element_type.superclass == Definitions::Field::Custom
-              Definitions::Field::Array.new(
-                field.name,
-                **field.options,
-                element_type: remove_hash(field.attributes[:element_type]).to_sym,
-                primary_key: field.primary_key?
-              )
-            else
-              field
-            end
+          if field.custom?
+            field.with_type(remove_hash(field.type))
+          elsif field.array? && field.custom_element_type?
+            field.with_attribute(:element_type, remove_hash(field.element_type.type).to_sym)
           else
-            type = if field.is_a?(Definitions::Field::Custom)
-              remove_hash(field.type)
-            else
-              field.type
-            end
-
-            Definitions::Field.build(
-              field.name,
-              type,
-              primary_key: field.primary_key?,
-              **field.options
-            )
+            field
           end
         end
       end

--- a/lib/db_schema/normalizer.rb
+++ b/lib/db_schema/normalizer.rb
@@ -72,12 +72,9 @@ module DbSchema
     private
       def create_temporary_table!
         operation = Changes::CreateTable.new(
-          Definitions::Table.new(
-            temporary_table_name,
-            fields:  rename_types(table.fields),
-            indices: rename_indices(table.indices),
-            checks:  table.checks
-          )
+          table.with_name(temporary_table_name)
+            .with_fields(rename_types(table.fields))
+            .with_indices(rename_indices(table.indices))
         )
 
         Runner.new([operation]).run!
@@ -86,13 +83,10 @@ module DbSchema
       def read_temporary_table
         temporary_table = Reader.read_table(temporary_table_name)
 
-        Definitions::Table.new(
-          remove_hash(temporary_table.name),
-          fields:       rename_types_back(temporary_table.fields),
-          indices:      rename_indices_back(temporary_table.indices),
-          checks:       temporary_table.checks,
-          foreign_keys: table.foreign_keys
-        )
+        temporary_table.with_name(table.name)
+          .with_fields(rename_types_back(temporary_table.fields))
+          .with_indices(rename_indices_back(temporary_table.indices))
+          .with_foreign_keys(table.foreign_keys)
       end
 
       def rename_types(fields)

--- a/lib/db_schema/normalizer.rb
+++ b/lib/db_schema/normalizer.rb
@@ -72,10 +72,12 @@ module DbSchema
     private
       def create_temporary_table!
         operation = Changes::CreateTable.new(
-          temporary_table_name,
-          fields:  rename_types(table.fields),
-          indices: rename_indices(table.indices),
-          checks:  table.checks
+          Definitions::Table.new(
+            temporary_table_name,
+            fields:  rename_types(table.fields),
+            indices: rename_indices(table.indices),
+            checks:  table.checks
+          )
         )
 
         Runner.new([operation]).run!

--- a/lib/db_schema/reader.rb
+++ b/lib/db_schema/reader.rb
@@ -298,7 +298,7 @@ SELECT extname
             Utils.rename_keys(
               Utils.filter_by_keys(data, :element_type, :element_custom_type_name)
             ) do |attributes|
-              attributes[:of] = if attributes[:element_type] == 'USER-DEFINED'
+              attributes[:element_type] = if attributes[:element_type] == 'USER-DEFINED'
                 attributes[:element_custom_type_name]
               else
                 attributes[:element_type]

--- a/lib/db_schema/runner.rb
+++ b/lib/db_schema/runner.rb
@@ -56,8 +56,8 @@ module DbSchema
 
     class << self
       def create_table(change)
-        DbSchema.connection.create_table(change.name) do
-          change.fields.each do |field|
+        DbSchema.connection.create_table(change.table.name) do
+          change.table.fields.each do |field|
             if field.primary_key?
               primary_key(field.name)
             else
@@ -66,7 +66,7 @@ module DbSchema
             end
           end
 
-          change.indices.each do |index|
+          change.table.indices.each do |index|
             index(
               index.columns_to_sequel,
               name:   index.name,
@@ -76,7 +76,7 @@ module DbSchema
             )
           end
 
-          change.checks.each do |check|
+          change.table.checks.each do |check|
             constraint(check.name, check.condition)
           end
         end

--- a/lib/db_schema/runner.rb
+++ b/lib/db_schema/runner.rb
@@ -189,7 +189,7 @@ module DbSchema
               change.enum_name,
               using: "#{field_name}::#{change.enum_name}"
             )
-            set_column_default(field_name, default_value)
+            set_column_default(field_name, default_value) unless default_value.nil?
           end
         end
       end

--- a/lib/db_schema/runner.rb
+++ b/lib/db_schema/runner.rb
@@ -133,16 +133,16 @@ module DbSchema
               set_column_default(element.name, Runner.default_to_sequel(element.new_default))
             when Changes::CreateIndex
               add_index(
-                element.columns_to_sequel,
-                name:   element.name,
-                unique: element.unique?,
-                type:   element.type,
-                where:  element.condition
+                element.index.columns_to_sequel,
+                name:   element.index.name,
+                unique: element.index.unique?,
+                type:   element.index.type,
+                where:  element.index.condition
               )
             when Changes::DropIndex
               drop_index([], name: element.name)
             when Changes::CreateCheckConstraint
-              add_constraint(element.name, element.condition)
+              add_constraint(element.check.name, element.check.condition)
             when Changes::DropCheckConstraint
               drop_constraint(element.name)
             end

--- a/lib/db_schema/runner.rb
+++ b/lib/db_schema/runner.rb
@@ -87,9 +87,9 @@ module DbSchema
       end
 
       def alter_table(change)
-        DbSchema.connection.alter_table(change.name) do
+        DbSchema.connection.alter_table(change.table_name) do
           Utils.sort_by_class(
-            change.fields + change.indices + change.checks,
+            change.changes,
             [
               DbSchema::Changes::DropPrimaryKey,
               DbSchema::Changes::DropCheckConstraint,

--- a/lib/db_schema/runner.rb
+++ b/lib/db_schema/runner.rb
@@ -41,7 +41,6 @@ module DbSchema
         changes,
         [
           Changes::CreateExtension,
-          Changes::AddValueToEnum,
           Changes::DropForeignKey,
           Changes::AlterEnumValues,
           Changes::CreateEnum,

--- a/lib/db_schema/runner.rb
+++ b/lib/db_schema/runner.rb
@@ -163,7 +163,7 @@ module DbSchema
       end
 
       def create_enum(change)
-        DbSchema.connection.create_enum(change.name, change.values)
+        DbSchema.connection.create_enum(change.enum.name, change.enum.values)
       end
 
       def drop_enum(change)
@@ -201,7 +201,7 @@ module DbSchema
       end
 
       def create_extension(change)
-        DbSchema.connection.run(%Q(CREATE EXTENSION "#{change.name}"))
+        DbSchema.connection.run(%Q(CREATE EXTENSION "#{change.extension.name}"))
       end
 
       def drop_extension(change)

--- a/lib/db_schema/runner.rb
+++ b/lib/db_schema/runner.rb
@@ -171,10 +171,10 @@ module DbSchema
       end
 
       def alter_enum_values(change)
-        change.enum_fields.each do |table_name, field_name, default_value|
+        change.enum_fields.each do |table_name, field_name|
           DbSchema.connection.alter_table(table_name) do
             set_column_type(field_name, :VARCHAR)
-            set_column_default(field_name, nil) unless default_value.nil?
+            set_column_default(field_name, nil)
           end
         end
 

--- a/lib/db_schema/runner.rb
+++ b/lib/db_schema/runner.rb
@@ -46,6 +46,7 @@ module DbSchema
           Changes::CreateExtension,
           Changes::AddValueToEnum,
           Changes::DropForeignKey,
+          Changes::AlterEnumValues,
           Changes::CreateEnum,
           Changes::CreateTable,
           Changes::AlterTable,

--- a/lib/db_schema/validator.rb
+++ b/lib/db_schema/validator.rb
@@ -19,6 +19,17 @@ module DbSchema
               elsif !field.default.nil? && !type.values.include?(field.default.to_sym)
                 errors << %(Field "#{table.name}.#{field.name}" has invalid default value "#{field.default}" (valid values are #{type.values.map(&:to_s)}))
               end
+            elsif field.is_a?(Definitions::Field::Array)
+              element_type = Definitions::Field.type_class_for(field.attributes[:element_type])
+
+              if element_type.superclass == Definitions::Field::Custom
+                type = schema.enums.find { |enum| enum.name == element_type.type }
+
+                if type.nil?
+                  error_message = %(Array field "#{table.name}.#{field.name}" has unknown element type "#{element_type.type}")
+                  errors << error_message
+                end
+              end
             end
           end
 

--- a/lib/db_schema/validator.rb
+++ b/lib/db_schema/validator.rb
@@ -16,10 +16,8 @@ module DbSchema
               if type.nil?
                 error_message = %(Field "#{table.name}.#{field.name}" has unknown type "#{field.type}")
                 errors << error_message
-              end
-
-              if !field.default.nil? && !type.values.include?(field.default.to_sym)
-                errors << %(Field "#{table.name}.#{field.name}" has invalid default value "#{field.default}")
+              elsif !field.default.nil? && !type.values.include?(field.default.to_sym)
+                errors << %(Field "#{table.name}.#{field.name}" has invalid default value "#{field.default}" (valid values are #{type.values.map(&:to_s)}))
               end
             end
           end

--- a/lib/db_schema/validator.rb
+++ b/lib/db_schema/validator.rb
@@ -11,9 +11,15 @@ module DbSchema
 
           table.fields.each do |field|
             if field.is_a?(Definitions::Field::Custom)
-              unless schema.enums.map(&:name).include?(field.type)
+              type = schema.enums.find { |enum| enum.name == field.type }
+
+              if type.nil?
                 error_message = %(Field "#{table.name}.#{field.name}" has unknown type "#{field.type}")
                 errors << error_message
+              end
+
+              if !field.default.nil? && !type.values.include?(field.default.to_sym)
+                errors << %(Field "#{table.name}.#{field.name}" has invalid default value "#{field.default}")
               end
             end
           end

--- a/lib/db_schema/validator.rb
+++ b/lib/db_schema/validator.rb
@@ -12,7 +12,7 @@ module DbSchema
           end
 
           table.fields.each do |field|
-            if field.is_a?(Definitions::Field::Custom)
+            if field.custom?
               type = schema.enums.find { |enum| enum.name == field.type }
 
               if type.nil?
@@ -21,23 +21,19 @@ module DbSchema
               elsif !field.default.nil? && !type.values.include?(field.default.to_sym)
                 errors << %(Field "#{table.name}.#{field.name}" has invalid default value "#{field.default}" (valid values are #{type.values.map(&:to_s)}))
               end
-            elsif field.is_a?(Definitions::Field::Array)
-              element_type = Definitions::Field.type_class_for(field.attributes[:element_type])
+            elsif field.array? && field.custom_element_type?
+              type = schema.enums.find { |enum| enum.name == field.element_type.type }
 
-              if element_type.superclass == Definitions::Field::Custom
-                type = schema.enums.find { |enum| enum.name == element_type.type }
+              if type.nil?
+                error_message = %(Array field "#{table.name}.#{field.name}" has unknown element type "#{field.element_type.type}")
+                errors << error_message
+              elsif !field.default.nil?
+                default_array  = Sequel::Postgres::PGArray::Parser.new(field.default).parse.map(&:to_sym)
+                invalid_values = default_array - type.values
 
-                if type.nil?
-                  error_message = %(Array field "#{table.name}.#{field.name}" has unknown element type "#{element_type.type}")
+                if invalid_values.any?
+                  error_message = %(Array field "#{table.name}.#{field.name}" has invalid default value #{default_array.map(&:to_s)} (valid values are #{type.values.map(&:to_s)}))
                   errors << error_message
-                elsif !field.default.nil?
-                  default_array  = Sequel::Postgres::PGArray::Parser.new(field.default).parse.map(&:to_sym)
-                  invalid_values = default_array - type.values
-
-                  if invalid_values.any?
-                    error_message = %(Array field "#{table.name}.#{field.name}" has invalid default value #{default_array.map(&:to_s)} (valid values are #{type.values.map(&:to_s)}))
-                    errors << error_message
-                  end
                 end
               end
             end

--- a/spec/db_schema/changes_spec.rb
+++ b/spec/db_schema/changes_spec.rb
@@ -248,22 +248,28 @@ RSpec.describe DbSchema::Changes do
           DbSchema::Changes::DropColumn.new(:age),
           DbSchema::Changes::DropIndex.new(:users_name_index),
           DbSchema::Changes::CreateIndex.new(
-            name:      :users_name_index,
-            columns:   [DbSchema::Definitions::Index::Expression.new('lower(name)')],
-            unique:    true,
-            condition: 'email IS NOT NULL'
+            DbSchema::Definitions::Index.new(
+              name:      :users_name_index,
+              columns:   [DbSchema::Definitions::Index::Expression.new('lower(name)')],
+              unique:    true,
+              condition: 'email IS NOT NULL'
+            )
           ),
           DbSchema::Changes::CreateIndex.new(
-            name:    :users_email_index,
-            columns: [DbSchema::Definitions::Index::TableField.new(:email, order: :desc)],
-            type:    :hash,
-            unique:  true
+            DbSchema::Definitions::Index.new(
+              name:    :users_email_index,
+              columns: [DbSchema::Definitions::Index::TableField.new(:email, order: :desc)],
+              type:    :hash,
+              unique:  true
+            )
           ),
           DbSchema::Changes::DropIndex.new(:users_type_index),
           DbSchema::Changes::DropCheckConstraint.new(:location_check),
           DbSchema::Changes::CreateCheckConstraint.new(
-            name:      :location_check,
-            condition: 'city_id IS NOT NULL OR country_id IS NOT NULL'
+            DbSchema::Definitions::CheckConstraint.new(
+              name:      :location_check,
+              condition: 'city_id IS NOT NULL OR country_id IS NOT NULL'
+            )
           )
         ])
 

--- a/spec/db_schema/changes_spec.rb
+++ b/spec/db_schema/changes_spec.rb
@@ -385,7 +385,7 @@ RSpec.describe DbSchema::Changes do
       let(:desired_schema) do
         DbSchema::Definitions::Schema.new(
           enums: [
-            DbSchema::Definitions::Enum.new(:happiness, desired_values)
+            DbSchema::Definitions::Enum.new(:happiness, %(happy good ok moderate bad))
           ]
         )
       end
@@ -393,88 +393,17 @@ RSpec.describe DbSchema::Changes do
       let(:actual_schema) do
         DbSchema::Definitions::Schema.new(
           enums: [
-            DbSchema::Definitions::Enum.new(:happiness, actual_values)
+            DbSchema::Definitions::Enum.new(:happiness, %(good moderate ok bad unhappy))
           ]
         )
       end
 
-      context 'by adding new values' do
-        context 'to the end' do
-          let(:desired_values) { %i(good ok bad unhappy) }
-          let(:actual_values)  { %i(good ok bad) }
+      it 'returns a Changes::AlterEnumValues' do
+        changes = DbSchema::Changes.between(desired_schema, actual_schema)
 
-          it 'returns a Changes::AddValueToEnum' do
-            changes = DbSchema::Changes.between(desired_schema, actual_schema)
-
-            expect(changes.count).to eq(1)
-            expect(changes).to eq([
-              DbSchema::Changes::AddValueToEnum.new(:happiness, :unhappy)
-            ])
-          end
-        end
-
-        context 'to the beginning' do
-          let(:desired_values) { %i(happy good ok bad) }
-          let(:actual_values)  { %i(good ok bad) }
-
-          it 'returns a Changes::AddValueToEnum with before: :good' do
-            changes = DbSchema::Changes.between(desired_schema, actual_schema)
-
-            expect(changes).to eq([
-              DbSchema::Changes::AddValueToEnum.new(:happiness, :happy, before: :good)
-            ])
-          end
-        end
-
-        context 'into the middle' do
-          let(:desired_values) { %i(good ok worried bad) }
-          let(:actual_values)  { %i(good ok bad) }
-
-          it 'returns a Changes::AddValueToEnum with before: :bad' do
-            changes = DbSchema::Changes.between(desired_schema, actual_schema)
-
-            expect(changes).to eq([
-              DbSchema::Changes::AddValueToEnum.new(:happiness, :worried, before: :bad)
-            ])
-          end
-        end
-
-        context 'with multiple values' do
-          let(:desired_values) { %i(happy good ok worried bad unhappy) }
-          let(:actual_values)  { %i(good ok bad) }
-
-          it 'returns appropriate AddValueToEnum objects in reverse order' do
-            changes = DbSchema::Changes.between(desired_schema, actual_schema)
-
-            expect(changes).to eq([
-              DbSchema::Changes::AddValueToEnum.new(:happiness, :unhappy),
-              DbSchema::Changes::AddValueToEnum.new(:happiness, :worried, before: :bad),
-              DbSchema::Changes::AddValueToEnum.new(:happiness, :happy, before: :good)
-            ])
-          end
-        end
-      end
-
-      context 'by removing values' do
-        let(:desired_values) { %i(happy ok unhappy) }
-        let(:actual_values)  { %i(happy good ok bad unhappy) }
-
-        it 'raises a DbSchema::UnsupportedOperation' do
-          expect {
-            DbSchema::Changes.between(desired_schema, actual_schema)
-          }.to raise_error(DbSchema::UnsupportedOperation)
-        end
-      end
-
-      context 'by reordering values' do
-        let(:desired_values) { %i(happy ok moderate sad) }
-        let(:actual_values)  { %i(moderate ok sad) }
-
-        it 'raises a DbSchema::UnsupportedOperation' do
-          expect {
-            DbSchema::Changes.between(desired_schema, actual_schema)
-          }.to raise_error(DbSchema::UnsupportedOperation)
-        end
+        expect(changes).to eq([
+          DbSchema::Changes::AlterEnumValues.new(:happiness, desired_schema.enums.first.values, [])
+        ])
       end
     end
 

--- a/spec/db_schema/changes_spec.rb
+++ b/spec/db_schema/changes_spec.rb
@@ -471,7 +471,7 @@ RSpec.describe DbSchema::Changes do
               tables: [
                 DbSchema::Definitions::Table.new(:users,
                   fields: [
-                    DbSchema::Definitions::Field::Array.new(:roles, element_type: :user_role, default: '[]')
+                    DbSchema::Definitions::Field::Array.new(:roles, element_type: :user_role, default: '{}')
                   ]
                 )
               ],
@@ -486,7 +486,7 @@ RSpec.describe DbSchema::Changes do
               tables: [
                 DbSchema::Definitions::Table.new(:users,
                   fields: [
-                    DbSchema::Definitions::Field::Array.new(:roles, element_type: :user_role, default: '[]')
+                    DbSchema::Definitions::Field::Array.new(:roles, element_type: :user_role, default: '{}')
                   ]
                 )
               ],
@@ -507,7 +507,7 @@ RSpec.describe DbSchema::Changes do
                   {
                     table_name:  :users,
                     field_name:  :roles,
-                    new_default: '[]',
+                    new_default: '{}',
                     array:       true
                   }
                 ]

--- a/spec/db_schema/changes_spec.rb
+++ b/spec/db_schema/changes_spec.rb
@@ -376,7 +376,9 @@ RSpec.describe DbSchema::Changes do
 
         expect(changes.count).to eq(2)
         expect(changes).to include(
-          DbSchema::Changes::CreateEnum.new(:happiness, %i(good ok bad))
+          DbSchema::Changes::CreateEnum.new(
+            DbSchema::Definitions::Enum.new(:happiness, %i(good ok bad))
+          )
         )
         expect(changes).to include(
           DbSchema::Changes::DropEnum.new(:skill)
@@ -543,7 +545,9 @@ RSpec.describe DbSchema::Changes do
 
         expect(changes.count).to eq(2)
         expect(changes).to include(
-          DbSchema::Changes::CreateExtension.new(:ltree)
+          DbSchema::Changes::CreateExtension.new(
+            DbSchema::Definitions::Extension.new(:ltree)
+          )
         )
         expect(changes).to include(
           DbSchema::Changes::DropExtension.new(:hstore)

--- a/spec/db_schema/changes_spec.rb
+++ b/spec/db_schema/changes_spec.rb
@@ -88,9 +88,12 @@ RSpec.describe DbSchema::Changes do
 
         expect(changes).to include(
           DbSchema::Changes::CreateTable.new(
-            :users,
-            fields: users_fields,
-            checks: users_checks
+            DbSchema::Definitions::Table.new(
+              :users,
+              fields:       users_fields,
+              checks:       users_checks,
+              foreign_keys: users_foreign_keys
+            )
           )
         )
         expect(changes).to include(DbSchema::Changes::DropTable.new(:posts))

--- a/spec/db_schema/changes_spec.rb
+++ b/spec/db_schema/changes_spec.rb
@@ -415,7 +415,7 @@ RSpec.describe DbSchema::Changes do
             tables: [
               DbSchema::Definitions::Table.new(:people,
                 fields: [
-                  DbSchema::Definitions::Field::Custom.class_for(:happiness).new(:happiness, default: 'ok')
+                  DbSchema::Definitions::Field::Custom.class_for(:happiness).new(:happiness, default: 'good')
                 ]
               )
             ],
@@ -430,7 +430,7 @@ RSpec.describe DbSchema::Changes do
             tables: [
               DbSchema::Definitions::Table.new(:people,
                 fields: [
-                  DbSchema::Definitions::Field::Custom.class_for(:happiness).new(:happiness, default: 'ok')
+                  DbSchema::Definitions::Field::Custom.class_for(:happiness).new(:happiness, default: 'happy')
                 ]
               )
             ],
@@ -444,10 +444,16 @@ RSpec.describe DbSchema::Changes do
           changes = DbSchema::Changes.between(desired_schema, actual_schema)
 
           expect(changes).to eq([
+            DbSchema::Changes::AlterTable.new(
+              :people,
+              fields: [
+                DbSchema::Changes::AlterColumnDefault.new(:happiness, new_default: 'good')
+              ]
+            ),
             DbSchema::Changes::AlterEnumValues.new(
               :happiness,
               desired_values,
-              [[:people, :happiness, 'ok']]
+              [[:people, :happiness, 'good']]
             )
           ])
         end

--- a/spec/db_schema/changes_spec.rb
+++ b/spec/db_schema/changes_spec.rb
@@ -415,7 +415,7 @@ RSpec.describe DbSchema::Changes do
             tables: [
               DbSchema::Definitions::Table.new(:people,
                 fields: [
-                  DbSchema::Definitions::Field::Custom.class_for(:happiness).new(:happiness)
+                  DbSchema::Definitions::Field::Custom.class_for(:happiness).new(:happiness, default: 'ok')
                 ]
               )
             ],
@@ -430,7 +430,7 @@ RSpec.describe DbSchema::Changes do
             tables: [
               DbSchema::Definitions::Table.new(:people,
                 fields: [
-                  DbSchema::Definitions::Field::Custom.class_for(:happiness).new(:happiness)
+                  DbSchema::Definitions::Field::Custom.class_for(:happiness).new(:happiness, default: 'ok')
                 ]
               )
             ],
@@ -447,7 +447,7 @@ RSpec.describe DbSchema::Changes do
             DbSchema::Changes::AlterEnumValues.new(
               :happiness,
               desired_values,
-              [DbSchema::Definitions::Field::Custom.class_for(:happiness).new(:happiness)]
+              [[:people, :happiness, 'ok']]
             )
           ])
         end

--- a/spec/db_schema/changes_spec.rb
+++ b/spec/db_schema/changes_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe DbSchema::Changes do
         alter_table = changes.first
         expect(alter_table).to be_a(DbSchema::Changes::AlterTable)
 
-        expect(alter_table.fields).to eq([
+        expect(alter_table.changes).to eq([
           DbSchema::Changes::CreatePrimaryKey.new(:id),
           DbSchema::Changes::AlterColumnType.new(:name, new_type: :varchar, length: 60),
           DbSchema::Changes::CreateColumn.new(DbSchema::Definitions::Field::Varchar.new(:email, null: false)),
@@ -245,10 +245,7 @@ RSpec.describe DbSchema::Changes do
           DbSchema::Changes::DisallowNull.new(:type),
           DbSchema::Changes::AlterColumnDefault.new(:type, new_default: 'guest'),
           DbSchema::Changes::AlterColumnType.new(:status, new_type: :user_status),
-          DbSchema::Changes::DropColumn.new(:age)
-        ])
-
-        expect(alter_table.indices).to eq([
+          DbSchema::Changes::DropColumn.new(:age),
           DbSchema::Changes::DropIndex.new(:users_name_index),
           DbSchema::Changes::CreateIndex.new(
             name:      :users_name_index,
@@ -262,10 +259,7 @@ RSpec.describe DbSchema::Changes do
             type:    :hash,
             unique:  true
           ),
-          DbSchema::Changes::DropIndex.new(:users_type_index)
-        ])
-
-        expect(alter_table.checks).to eq([
+          DbSchema::Changes::DropIndex.new(:users_type_index),
           DbSchema::Changes::DropCheckConstraint.new(:location_check),
           DbSchema::Changes::CreateCheckConstraint.new(
             name:      :location_check,
@@ -449,7 +443,7 @@ RSpec.describe DbSchema::Changes do
           expect(changes).to eq([
             DbSchema::Changes::AlterTable.new(
               :people,
-              fields: [
+              [
                 DbSchema::Changes::AlterColumnDefault.new(:happiness, new_default: 'good')
               ]
             ),

--- a/spec/db_schema/changes_spec.rb
+++ b/spec/db_schema/changes_spec.rb
@@ -420,7 +420,7 @@ RSpec.describe DbSchema::Changes do
             tables: [
               DbSchema::Definitions::Table.new(:people,
                 fields: [
-                  DbSchema::Definitions::Field::Custom.class_for(:happiness).new(:happiness, default: 'good')
+                  DbSchema::Definitions::Field::Custom.class_for(:happiness).new(:happiness, default: 'happy')
                 ]
               )
             ],
@@ -435,7 +435,7 @@ RSpec.describe DbSchema::Changes do
             tables: [
               DbSchema::Definitions::Table.new(:people,
                 fields: [
-                  DbSchema::Definitions::Field::Custom.class_for(:happiness).new(:happiness, default: 'happy')
+                  DbSchema::Definitions::Field::Custom.class_for(:happiness).new(:happiness, default: 'unhappy')
                 ]
               )
             ],
@@ -452,7 +452,7 @@ RSpec.describe DbSchema::Changes do
             DbSchema::Changes::AlterTable.new(
               :people,
               [
-                DbSchema::Changes::AlterColumnDefault.new(:happiness, new_default: 'good')
+                DbSchema::Changes::AlterColumnDefault.new(:happiness, new_default: 'happy')
               ]
             ),
             DbSchema::Changes::AlterEnumValues.new(
@@ -462,7 +462,7 @@ RSpec.describe DbSchema::Changes do
                 {
                   table_name:  :people,
                   field_name:  :happiness,
-                  new_default: 'good',
+                  new_default: 'happy',
                   array:       false
                 }
               ]

--- a/spec/db_schema/normalizer_spec.rb
+++ b/spec/db_schema/normalizer_spec.rb
@@ -58,9 +58,15 @@ RSpec.describe DbSchema::Normalizer do
     end
 
     before(:each) do
-      add_hstore = DbSchema::Changes::CreateExtension.new(:hstore)
-      add_happiness = DbSchema::Changes::CreateEnum.new(:happiness, %i(good bad))
-      add_role = DbSchema::Changes::CreateEnum.new(:user_role, %i(admin))
+      add_hstore = DbSchema::Changes::CreateExtension.new(
+        DbSchema::Definitions::Extension.new(:hstore)
+      )
+      add_happiness = DbSchema::Changes::CreateEnum.new(
+        DbSchema::Definitions::Enum.new(:happiness, %i(good bad))
+      )
+      add_role = DbSchema::Changes::CreateEnum.new(
+        DbSchema::Definitions::Enum.new(:user_role, %i(admin))
+      )
 
       fields = raw_table.fields.take(5)
       fields << DbSchema::Definitions::Field::Custom.class_for(:happiness).new(:happiness)

--- a/spec/db_schema/normalizer_spec.rb
+++ b/spec/db_schema/normalizer_spec.rb
@@ -67,10 +67,12 @@ RSpec.describe DbSchema::Normalizer do
       fields << DbSchema::Definitions::Field::Array.new(:roles, element_type: :user_role, default: '{admin}')
 
       create_table = DbSchema::Changes::CreateTable.new(
-        :users,
-        fields:  fields,
-        indices: raw_table.indices,
-        checks:  raw_table.checks
+        DbSchema::Definitions::Table.new(
+          :users,
+          fields:  fields,
+          indices: raw_table.indices,
+          checks:  raw_table.checks
+        )
       )
 
       DbSchema::Runner.new([add_hstore, add_happiness, add_role, create_table]).run!

--- a/spec/db_schema/runner_spec.rb
+++ b/spec/db_schema/runner_spec.rb
@@ -170,22 +170,11 @@ RSpec.describe DbSchema::Runner do
 
     context 'with AlterTable' do
       let(:changes) do
-        [
-          DbSchema::Changes::AlterTable.new(
-            :people,
-            fields:  field_changes,
-            indices: index_changes,
-            checks:  check_changes
-          )
-        ]
+        [DbSchema::Changes::AlterTable.new(:people, table_changes)]
       end
 
-      let(:field_changes) { [] }
-      let(:index_changes) { [] }
-      let(:check_changes) { [] }
-
       context 'containing CreateColumn & DropColumn' do
-        let(:field_changes) do
+        let(:table_changes) do
           [
             DbSchema::Changes::CreateColumn.new(DbSchema::Definitions::Field::Varchar.new(:first_name)),
             DbSchema::Changes::CreateColumn.new(
@@ -231,7 +220,7 @@ RSpec.describe DbSchema::Runner do
       end
 
       context 'containing RenameColumn' do
-        let(:field_changes) do
+        let(:table_changes) do
           [
             DbSchema::Changes::RenameColumn.new(old_name: :name, new_name: :full_name)
           ]
@@ -248,7 +237,7 @@ RSpec.describe DbSchema::Runner do
       end
 
       context 'containing AlterColumnType' do
-        let(:field_changes) do
+        let(:table_changes) do
           [
             DbSchema::Changes::AlterColumnType.new(:name, new_type: :text)
           ]
@@ -262,7 +251,7 @@ RSpec.describe DbSchema::Runner do
         end
 
         context 'that changes field attributes' do
-          let(:field_changes) do
+          let(:table_changes) do
             [
               DbSchema::Changes::AlterColumnType.new(:address, new_type: :varchar),
               DbSchema::Changes::AlterColumnType.new(:country_name, new_type: :varchar, length: 40),
@@ -287,7 +276,7 @@ RSpec.describe DbSchema::Runner do
       end
 
       context 'containing CreatePrimaryKey' do
-        let(:field_changes) do
+        let(:table_changes) do
           [
             DbSchema::Changes::CreatePrimaryKey.new(name: :name)
           ]
@@ -301,7 +290,7 @@ RSpec.describe DbSchema::Runner do
       end
 
       context 'containing DropPrimaryKey' do
-        let(:field_changes) do
+        let(:table_changes) do
           [
             DbSchema::Changes::DropPrimaryKey.new(name: :id)
           ]
@@ -315,7 +304,7 @@ RSpec.describe DbSchema::Runner do
       end
 
       context 'containing AllowNull & DisallowNull' do
-        let(:field_changes) do
+        let(:table_changes) do
           [
             DbSchema::Changes::AllowNull.new(:address),
             DbSchema::Changes::DisallowNull.new(:name)
@@ -332,7 +321,7 @@ RSpec.describe DbSchema::Runner do
       end
 
       context 'containing AlterColumnDefault' do
-        let(:field_changes) do
+        let(:table_changes) do
           [
             DbSchema::Changes::AlterColumnDefault.new(:name, new_default: 'John Smith')
           ]
@@ -346,7 +335,7 @@ RSpec.describe DbSchema::Runner do
         end
 
         context 'with an expression' do
-          let(:field_changes) do
+          let(:table_changes) do
             [
               DbSchema::Changes::AlterColumnDefault.new(:created_at, new_default: :'now()')
             ]
@@ -362,16 +351,11 @@ RSpec.describe DbSchema::Runner do
       end
 
       context 'containing CreateIndex & DropIndex' do
-        let(:field_changes) do
+        let(:table_changes) do
           [
             DbSchema::Changes::CreateColumn.new(
               DbSchema::Definitions::Field::Array.new(:interests, element_type: :varchar)
-            )
-          ]
-        end
-
-        let(:index_changes) do
-          [
+            ),
             DbSchema::Changes::CreateIndex.new(
               name:      :people_name_index,
               columns:   [DbSchema::Definitions::Index::Expression.new('lower(name)', order: :desc)],
@@ -409,7 +393,7 @@ RSpec.describe DbSchema::Runner do
       end
 
       context 'containing CreateCheckConstraint & DropCheckConstraint' do
-        let(:check_changes) do
+        let(:table_changes) do
           [
             DbSchema::Changes::DropCheckConstraint.new(:address_length),
             DbSchema::Changes::CreateCheckConstraint.new(
@@ -431,16 +415,11 @@ RSpec.describe DbSchema::Runner do
       end
 
       context "creating a field along with it's index" do
-        let(:field_changes) do
+        let(:table_changes) do
           [
             DbSchema::Changes::CreateColumn.new(
               DbSchema::Definitions::Field::Varchar.new(:email)
-            )
-          ]
-        end
-
-        let(:index_changes) do
-          [
+            ),
             DbSchema::Changes::CreateIndex.new(
               name: :people_email_index,
               columns: [
@@ -470,14 +449,9 @@ RSpec.describe DbSchema::Runner do
       end
 
       context "dropping a field along with it's index" do
-        let(:field_changes) do
+        let(:table_changes) do
           [
-            DbSchema::Changes::DropColumn.new(:address)
-          ]
-        end
-
-        let(:index_changes) do
-          [
+            DbSchema::Changes::DropColumn.new(:address),
             DbSchema::Changes::DropIndex.new(:people_address_index)
           ]
         end
@@ -495,16 +469,11 @@ RSpec.describe DbSchema::Runner do
       end
 
       context "creating a field along with it's check constraint" do
-        let(:field_changes) do
+        let(:table_changes) do
           [
             DbSchema::Changes::CreateColumn.new(
               DbSchema::Definitions::Field::Varchar.new(:email)
-            )
-          ]
-        end
-
-        let(:check_changes) do
-          [
+            ),
             DbSchema::Changes::CreateCheckConstraint.new(
               name:      :email_length,
               condition: 'char_length(email) > 5'
@@ -530,14 +499,9 @@ RSpec.describe DbSchema::Runner do
       end
 
       context "dropping a field along with it's check constraint" do
-        let(:field_changes) do
+        let(:table_changes) do
           [
-            DbSchema::Changes::DropColumn.new(:address)
-          ]
-        end
-
-        let(:check_changes) do
-          [
+            DbSchema::Changes::DropColumn.new(:address),
             DbSchema::Changes::DropCheckConstraint.new(:address_length)
           ]
         end
@@ -646,17 +610,7 @@ RSpec.describe DbSchema::Runner do
           DbSchema::Changes::DropForeignKey.new(:other_old_table, :other_old_table_old_id_fkey),
           DbSchema::Changes::AlterTable.new(
             :referenced_table,
-            fields: [
-              DbSchema::Changes::DropColumn.new(:referenced_field)
-            ],
-            indices: [],
-            checks:  []
-          ),
-          DbSchema::Changes::AlterTable.new(
-            :referring_table,
-            fields:  [],
-            indices: [],
-            checks:  []
+            [DbSchema::Changes::DropColumn.new(:referenced_field)]
           ),
           DbSchema::Changes::DropForeignKey.new(:referring_table, :referring_table_old_id_fkey),
           DbSchema::Changes::DropForeignKey.new(:referring_table, :referring_table_referenced_field_fkey),
@@ -838,19 +792,16 @@ RSpec.describe DbSchema::Runner do
       changes = [
         DbSchema::Changes::AlterTable.new(
           :people,
-          fields: [
+          [
             DbSchema::Changes::CreateColumn.new(
               DbSchema::Definitions::Field::Varchar.new(:city_name)
-            )
-          ],
-          indices: [
+            ),
             DbSchema::Changes::CreateIndex.new(
               name:    :people_city_name_index,
               columns: [DbSchema::Definitions::Index::TableField.new(:city_name)],
               type:    :gist
             )
-          ],
-          checks: []
+          ]
         )
       ]
 

--- a/spec/db_schema/runner_spec.rb
+++ b/spec/db_schema/runner_spec.rb
@@ -357,15 +357,19 @@ RSpec.describe DbSchema::Runner do
               DbSchema::Definitions::Field::Array.new(:interests, element_type: :varchar)
             ),
             DbSchema::Changes::CreateIndex.new(
-              name:      :people_name_index,
-              columns:   [DbSchema::Definitions::Index::Expression.new('lower(name)', order: :desc)],
-              condition: 'name IS NOT NULL'
+              DbSchema::Definitions::Index.new(
+                name:      :people_name_index,
+                columns:   [DbSchema::Definitions::Index::Expression.new('lower(name)', order: :desc)],
+                condition: 'name IS NOT NULL'
+              )
             ),
             DbSchema::Changes::DropIndex.new(:people_address_index),
             DbSchema::Changes::CreateIndex.new(
-              name:    :people_interests_index,
-              columns: [DbSchema::Definitions::Index::TableField.new(:interests)],
-              type:    :gin
+              DbSchema::Definitions::Index.new(
+                name:    :people_interests_index,
+                columns: [DbSchema::Definitions::Index::TableField.new(:interests)],
+                type:    :gin
+              )
             )
           ]
         end
@@ -397,8 +401,10 @@ RSpec.describe DbSchema::Runner do
           [
             DbSchema::Changes::DropCheckConstraint.new(:address_length),
             DbSchema::Changes::CreateCheckConstraint.new(
-              name:      :min_address_length,
-              condition: 'character_length(address) >= 10'
+              DbSchema::Definitions::CheckConstraint.new(
+                name:      :min_address_length,
+                condition: 'character_length(address) >= 10'
+              )
             )
           ]
         end
@@ -421,10 +427,12 @@ RSpec.describe DbSchema::Runner do
               DbSchema::Definitions::Field::Varchar.new(:email)
             ),
             DbSchema::Changes::CreateIndex.new(
-              name: :people_email_index,
-              columns: [
-                DbSchema::Definitions::Index::TableField.new(:email)
-              ]
+              DbSchema::Definitions::Index.new(
+                name: :people_email_index,
+                columns: [
+                  DbSchema::Definitions::Index::TableField.new(:email)
+                ]
+              )
             )
           ]
         end
@@ -475,8 +483,10 @@ RSpec.describe DbSchema::Runner do
               DbSchema::Definitions::Field::Varchar.new(:email)
             ),
             DbSchema::Changes::CreateCheckConstraint.new(
-              name:      :email_length,
-              condition: 'char_length(email) > 5'
+              DbSchema::Definitions::CheckConstraint.new(
+                name:      :email_length,
+                condition: 'char_length(email) > 5'
+              )
             )
           ]
         end
@@ -797,9 +807,11 @@ RSpec.describe DbSchema::Runner do
               DbSchema::Definitions::Field::Varchar.new(:city_name)
             ),
             DbSchema::Changes::CreateIndex.new(
-              name:    :people_city_name_index,
-              columns: [DbSchema::Definitions::Index::TableField.new(:city_name)],
-              type:    :gist
+              DbSchema::Definitions::Index.new(
+                name:    :people_city_name_index,
+                columns: [DbSchema::Definitions::Index::TableField.new(:city_name)],
+                type:    :gist
+              )
             )
           ]
         )

--- a/spec/db_schema/runner_spec.rb
+++ b/spec/db_schema/runner_spec.rb
@@ -94,10 +94,12 @@ RSpec.describe DbSchema::Runner do
       let(:changes) do
         [
           DbSchema::Changes::CreateTable.new(
-            :users,
-            fields:  users_fields,
-            indices: users_indices,
-            checks:  users_checks
+            DbSchema::Definitions::Table.new(
+              :users,
+              fields:  users_fields,
+              indices: users_indices,
+              checks:  users_checks
+            )
           ),
           DbSchema::Changes::DropTable.new(:people)
         ]
@@ -667,12 +669,14 @@ RSpec.describe DbSchema::Runner do
             )
           ),
           DbSchema::Changes::CreateTable.new(
-            :new_table,
-            fields: [
-              DbSchema::Definitions::Field::Integer.new(:id, primary_key: true),
-              DbSchema::Definitions::Field::Integer.new(:other_new_id)
-            ],
-            indices: []
+            DbSchema::Definitions::Table.new(
+              :new_table,
+              fields: [
+                DbSchema::Definitions::Field::Integer.new(:id, primary_key: true),
+                DbSchema::Definitions::Field::Integer.new(:other_new_id)
+              ],
+              indices: []
+            )
           ),
           DbSchema::Changes::CreateForeignKey.new(
             :new_table,
@@ -683,11 +687,12 @@ RSpec.describe DbSchema::Runner do
             )
           ),
           DbSchema::Changes::CreateTable.new(
-            :other_new_table,
-            fields: [
-              DbSchema::Definitions::Field::Integer.new(:id, primary_key: true)
-            ],
-            indices: []
+            DbSchema::Definitions::Table.new(
+              :other_new_table,
+              fields: [
+                DbSchema::Definitions::Field::Integer.new(:id, primary_key: true)
+              ]
+            )
           )
         ]
       end

--- a/spec/db_schema/runner_spec.rb
+++ b/spec/db_schema/runner_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe DbSchema::Runner do
       DbSchema::Definitions::Field::Bit.new(:some_bit),
       DbSchema::Definitions::Field::Bit.new(:some_bits, length: 7),
       DbSchema::Definitions::Field::Varbit.new(:some_varbit, length: 250),
-      DbSchema::Definitions::Field::Array.new(:names, of: :varchar)
+      DbSchema::Definitions::Field::Array.new(:names, element_type: :varchar)
     ]
   end
 
@@ -362,7 +362,9 @@ RSpec.describe DbSchema::Runner do
       context 'containing CreateIndex & DropIndex' do
         let(:field_changes) do
           [
-            DbSchema::Changes::CreateColumn.new(DbSchema::Definitions::Field::Array.new(:interests, of: :varchar))
+            DbSchema::Changes::CreateColumn.new(
+              DbSchema::Definitions::Field::Array.new(:interests, element_type: :varchar)
+            )
           ]
         end
 

--- a/spec/db_schema/runner_spec.rb
+++ b/spec/db_schema/runner_spec.rb
@@ -676,7 +676,9 @@ RSpec.describe DbSchema::Runner do
 
       let(:changes) do
         [
-          DbSchema::Changes::CreateEnum.new(:happiness, %i(happy ok sad)),
+          DbSchema::Changes::CreateEnum.new(
+            DbSchema::Definitions::Enum.new(:happiness, %i(happy ok sad))
+          ),
           DbSchema::Changes::DropEnum.new(:status)
         ]
       end
@@ -777,8 +779,12 @@ RSpec.describe DbSchema::Runner do
 
       let(:changes) do
         [
-          DbSchema::Changes::CreateExtension.new(:ltree),
-          DbSchema::Changes::CreateExtension.new(:'uuid-ossp'),
+          DbSchema::Changes::CreateExtension.new(
+            DbSchema::Definitions::Extension.new(:ltree)
+          ),
+          DbSchema::Changes::CreateExtension.new(
+            DbSchema::Definitions::Extension.new(:'uuid-ossp')
+          ),
           DbSchema::Changes::DropExtension.new(:hstore)
         ]
       end

--- a/spec/db_schema/validator_spec.rb
+++ b/spec/db_schema/validator_spec.rb
@@ -282,6 +282,27 @@ RSpec.describe DbSchema::Validator do
           'Field "users.happiness" has invalid default value "crazy" (valid values are ["happy", "ok", "sad"])'
         ])
       end
+
+      context 'within an array' do
+        let(:users_fields) do
+          [
+            DbSchema::Definitions::Field::Integer.new(:id, primary_key: true),
+            DbSchema::Definitions::Field::Varchar.new(:name, null: false),
+            DbSchema::Definitions::Field::Array.new(:roles, element_type: :user_role, default: '{admin}')
+          ]
+        end
+
+        let(:enum) do
+          DbSchema::Definitions::Enum.new(:user_role, %i(user))
+        end
+
+        it 'returns an invalid result with errors' do
+          expect(result).not_to be_valid
+          expect(result.errors).to eq([
+            'Array field "users.roles" has invalid default value ["admin"] (valid values are ["user"])'
+          ])
+        end
+      end
     end
   end
 end

--- a/spec/db_schema/validator_spec.rb
+++ b/spec/db_schema/validator_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe DbSchema::Validator do
           DbSchema::Definitions::Field::Varchar.new(:first_name, null: false),
           DbSchema::Definitions::Field::Varchar.new(:last_name, null: false),
           DbSchema::Definitions::Field::Integer.new(:age),
-          DbSchema::Definitions::Field::Custom.class_for(:user_sorrow).new(:sorrow)
+          DbSchema::Definitions::Field::Custom.class_for(:user_sorrow).new(:sorrow, default: 'depressed')
         ]
       end
 
@@ -260,7 +260,7 @@ RSpec.describe DbSchema::Validator do
       it 'returns an invalid result with errors' do
         expect(result).not_to be_valid
         expect(result.errors).to eq([
-          'Field "users.happiness" has invalid default value "crazy"'
+          'Field "users.happiness" has invalid default value "crazy" (valid values are ["happy", "ok", "sad"])'
         ])
       end
     end

--- a/spec/db_schema/validator_spec.rb
+++ b/spec/db_schema/validator_spec.rb
@@ -244,6 +244,25 @@ RSpec.describe DbSchema::Validator do
           'Field "users.sorrow" has unknown type "user_sorrow"'
         ])
       end
+
+      context 'within an array' do
+        let(:users_fields) do
+          [
+            DbSchema::Definitions::Field::Integer.new(:id, primary_key: true),
+            DbSchema::Definitions::Field::Varchar.new(:first_name, null: false),
+            DbSchema::Definitions::Field::Varchar.new(:last_name, null: false),
+            DbSchema::Definitions::Field::Integer.new(:age),
+            DbSchema::Definitions::Field::Array.new(:roles, element_type: :user_role)
+          ]
+        end
+
+        it 'returns an invalid result with errors' do
+          expect(result).not_to be_valid
+          expect(result.errors).to eq([
+            'Array field "users.roles" has unknown element type "user_role"'
+          ])
+        end
+      end
     end
 
     context 'on a schema with a enum field with invalid default value' do

--- a/spec/db_schema/validator_spec.rb
+++ b/spec/db_schema/validator_spec.rb
@@ -245,5 +245,24 @@ RSpec.describe DbSchema::Validator do
         ])
       end
     end
+
+    context 'on a schema with a enum field with invalid default value' do
+      let(:users_fields) do
+        [
+          DbSchema::Definitions::Field::Integer.new(:id, primary_key: true),
+          DbSchema::Definitions::Field::Varchar.new(:name, null: false),
+          DbSchema::Definitions::Field::Custom.class_for(:user_happiness).new(:happiness, default: 'crazy')
+        ]
+      end
+
+      let(:users_indices) { [] }
+
+      it 'returns an invalid result with errors' do
+        expect(result).not_to be_valid
+        expect(result.errors).to eq([
+          'Field "users.happiness" has invalid default value "crazy"'
+        ])
+      end
+    end
   end
 end

--- a/spec/db_schema_spec.rb
+++ b/spec/db_schema_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe DbSchema do
           t.varchar :first_name,  null: false, length: 30
           t.varchar :last_name,   null: false, length: 30
           t.varchar :email,       null: false
-          t.happiness :happiness, default: 'ok'
+          t.happiness :happiness, default: 'happy'
 
           t.index :first_name, last_name: :desc, name: :users_name_index
           t.index 'lower(email)', name: :users_email_index, unique: true
@@ -77,7 +77,7 @@ RSpec.describe DbSchema do
       expect(email.last[:db_type]).to eq('character varying')
       expect(email.last[:allow_null]).to eq(false)
       expect(happiness.first).to eq(:happiness)
-      expect(happiness.last[:default]).to eq("'ok'::happiness")
+      expect(happiness.last[:default]).to eq("'happy'::happiness")
       expect(first_name.first).to eq(:first_name)
       expect(first_name.last[:db_type]).to eq('character varying(30)')
       expect(first_name.last[:allow_null]).to eq(false)

--- a/spec/db_schema_spec.rb
+++ b/spec/db_schema_spec.rb
@@ -7,10 +7,13 @@ RSpec.describe DbSchema do
     before(:each) do
       subject.configure(database: 'db_schema_test', log_changes: false)
 
+      database.create_enum :happiness, %i(good ok bad)
+
       database.create_table :users do
-        column :id,    :Integer, primary_key: true
-        column :name,  :Varchar, null: false
-        column :email, :Varchar, size: 100
+        column :id,        :Integer, primary_key: true
+        column :name,      :Varchar, null: false
+        column :email,     :Varchar, size: 100
+        column :happiness, :happiness, default: 'ok'
 
         index :email
       end
@@ -27,11 +30,14 @@ RSpec.describe DbSchema do
 
     it 'applies the schema to the database' do
       subject.describe do |db|
+        db.enum :happiness, %i(happy ok unhappy)
+
         db.table :users do |t|
-          t.integer :id, primary_key: true
-          t.varchar :first_name, null: false, length: 30
-          t.varchar :last_name,  null: false, length: 30
-          t.varchar :email,      null: false
+          t.primary_key :id
+          t.varchar :first_name,  null: false, length: 30
+          t.varchar :last_name,   null: false, length: 30
+          t.varchar :email,       null: false
+          t.happiness :happiness, default: 'ok'
 
           t.index :first_name, last_name: :desc, name: :users_name_index
           t.index 'lower(email)', name: :users_email_index, unique: true
@@ -65,11 +71,13 @@ RSpec.describe DbSchema do
       expect(database.tables).to include(:posts)
       expect(database.tables).to include(:cities)
 
-      id, email, first_name, last_name = database.schema(:users)
+      id, email, happiness, first_name, last_name = database.schema(:users)
       expect(id.first).to eq(:id)
       expect(email.first).to eq(:email)
       expect(email.last[:db_type]).to eq('character varying')
       expect(email.last[:allow_null]).to eq(false)
+      expect(happiness.first).to eq(:happiness)
+      expect(happiness.last[:default]).to eq("'ok'::happiness")
       expect(first_name.first).to eq(:first_name)
       expect(first_name.last[:db_type]).to eq('character varying(30)')
       expect(first_name.last[:allow_null]).to eq(false)
@@ -132,6 +140,13 @@ RSpec.describe DbSchema do
       expect(country_id_fkey[:columns]).to eq([:country_id])
       expect(country_id_fkey[:table]).to eq(:countries)
       expect(country_id_fkey[:key]).to eq([:id])
+
+      enums = DbSchema::Reader.read_enums
+      expect(enums.count).to eq(1)
+
+      happiness = enums.first
+      expect(happiness.name).to eq(:happiness)
+      expect(happiness.values).to eq(%i(happy ok unhappy))
     end
 
     context 'with an invalid schema' do
@@ -241,6 +256,10 @@ Requested schema is invalid:
             drop_foreign_key([], name: foreign_key[:name])
           end
         end
+      end
+
+      DbSchema::Reader.read_schema.enums.each do |enum|
+        database.drop_enum(enum.name, cascade: true)
       end
 
       database.tables.each do |table_name|

--- a/spec/db_schema_spec.rb
+++ b/spec/db_schema_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe DbSchema do
     end
 
     it 'applies the schema to the database' do
+      pending 'Refactoring enum array support in Changes::AlterEnumValues'
+
       subject.describe do |db|
         db.enum :happiness, %i(happy ok unhappy)
 

--- a/spec/db_schema_spec.rb
+++ b/spec/db_schema_spec.rb
@@ -29,8 +29,6 @@ RSpec.describe DbSchema do
     end
 
     it 'applies the schema to the database' do
-      pending 'Refactoring enum array support in Changes::AlterEnumValues'
-
       subject.describe do |db|
         db.enum :happiness, %i(happy ok unhappy)
 


### PR DESCRIPTION
Now it is possible both to add and to remove values (reordering is also supported). All these operations are done within a transaction.

Internally everything is done with a `Changes::AlterEnumValues` operation: all table fields using the type being changed are converted to `varchar`, then the type is recreated with the new values and fields are converted to the new type.

Closes #5.